### PR TITLE
Forward-declare all used built-in functions, fixing issue #54, and becoming 25% faster while doing that

### DIFF
--- a/lib/WebCLAction.hpp
+++ b/lib/WebCLAction.hpp
@@ -80,7 +80,7 @@ class WebCLPreprocessorAction : public WebCLAction
 {
 public:
 
-    explicit WebCLPreprocessorAction(const char *output);
+    explicit WebCLPreprocessorAction(const char *output, std::string &builtinDecls);
     virtual ~WebCLPreprocessorAction();
 
     /// \see clang::FrontendAction
@@ -92,6 +92,12 @@ public:
 
     /// \see clang::FrontendAction
     virtual bool usesPreprocessorOnly() const;
+
+private:
+
+    /// Where to store additional builtin function forward declarations
+    /// needed by later AST parsing passes
+    std::string &builtinDecls_;
 };
 
 /// A base class for stages that use AST matchers for consuming ASTs.

--- a/lib/WebCLArguments.cpp
+++ b/lib/WebCLArguments.cpp
@@ -97,7 +97,7 @@ WebCLArguments::WebCLArguments(const std::string &inputSource, int argc, char co
     const int preprocessorInvocationSize =
         sizeof(preprocessorInvocation) / sizeof(preprocessorInvocation[0]);
     char const *preprocessorOptions[] = {
-        "-E", "-x", "cl"
+        "-E", "-x", "cl", "-fno-builtin", "-ffreestanding"
     };
     const int numPreprocessorOptions =
         sizeof(preprocessorOptions) / sizeof(preprocessorOptions[0]);
@@ -110,8 +110,8 @@ WebCLArguments::WebCLArguments(const std::string &inputSource, int argc, char co
     char const *validatorOptions[] = {
         "-x", "cl",
         "-Wno-implicit-function-declaration",
-        "-include", headerFilename,
-        "-include", builtinDeclFilename_
+        "-include", headerFilename, // has to be early (provides utility macros)
+        "-include", builtinDeclFilename_ // has to be late (uses utility macros)
     };
     const int numValidatorOptions =
         sizeof(validatorOptions) / sizeof(validatorOptions[0]);

--- a/lib/WebCLArguments.cpp
+++ b/lib/WebCLArguments.cpp
@@ -91,6 +91,9 @@ WebCLArguments::WebCLArguments(const std::string &inputSource, int argc, char co
     files_.push_back(TemporaryFile(-1, builtinDeclFilename_));
     close(builtinDeclDescriptor);
 
+    // TODO: add -Dcl_khr_fp16 etc definitions to preprocessor options
+    // based on extensions passed to clvValidate()
+
     char const *preprocessorInvocation[] = {
         "libclv", inputFilename, "--"
     };

--- a/lib/WebCLArguments.cpp
+++ b/lib/WebCLArguments.cpp
@@ -109,7 +109,6 @@ WebCLArguments::WebCLArguments(const std::string &inputSource, int argc, char co
         sizeof(validatorInvocation) / sizeof(validatorInvocation[0]);
     char const *validatorOptions[] = {
         "-x", "cl",
-        "-Wno-implicit-function-declaration",
         "-include", headerFilename, // has to be early (provides utility macros)
         "-include", builtinDeclFilename_ // has to be late (uses utility macros)
     };

--- a/lib/WebCLArguments.hpp
+++ b/lib/WebCLArguments.hpp
@@ -65,6 +65,11 @@ public:
     /// input file of the next tool in the pipeline.
     char const *getInput(int argc, char const **argv, bool createOutput = false);
 
+    /// Writes the given data into a file that is included as an input
+    /// by the matcher and validator tools due to their argv's
+    /// \return \c true on success, \c false on failure
+    bool supplyBuiltinDecls(const std::string &decls);
+
 private:
 
     /// Whether there is room for input file.
@@ -99,6 +104,10 @@ private:
     /// and remove them. Contains generated headers and output files.
     typedef std::vector<TemporaryFile> TemporaryFiles;
     TemporaryFiles files_;
+
+    /// Contains the name of a temporary header used to include
+    /// select builtin function declarations in matcher and validation stages
+    char const *builtinDeclFilename_;
 
     /// Save information about output files so that we can chain
     /// different tools properly. Contains only those files that are

--- a/lib/WebCLBuiltins.cpp
+++ b/lib/WebCLBuiltins.cpp
@@ -258,7 +258,13 @@ static struct {
                 "#ifdef cl_khr_fp64\n"
                 "double4 _CL_OVERLOADABLE cross(double4, double4);\n"
                 "double3 _CL_OVERLOADABLE cross(double3, double3);\n"
-                "#endif\n" }
+                "#endif\n" },
+    { "read_imagef", "float4 _CL_OVERLOADABLE read_imagef (image2d_t image, sampler_t sampler, int2 coord);\n"
+                     "float4 _CL_OVERLOADABLE read_imagef (image2d_t image, sampler_t sampler, float2 coord);\n" },
+    { "read_imageui", "uint4 _CL_OVERLOADABLE read_imageui (image2d_t image, sampler_t sampler, int2 coord);\n"
+                      "uint4 _CL_OVERLOADABLE read_imageui (image2d_t image, sampler_t sampler, float2 coord);\n" },
+    { "read_imagei", "int4 _CL_OVERLOADABLE read_imagei (image2d_t image, sampler_t sampler, int2 coord);\n"
+                     "int4 _CL_OVERLOADABLE read_imagei (image2d_t image, sampler_t sampler, float2 coord);\n" }
 };
 static const int numBuiltinDecls =
     sizeof(builtinDecls) / sizeof(builtinDecls[0]);

--- a/lib/WebCLBuiltins.cpp
+++ b/lib/WebCLBuiltins.cpp
@@ -264,7 +264,17 @@ static struct {
     { "read_imageui", "uint4 _CL_OVERLOADABLE read_imageui (image2d_t image, sampler_t sampler, int2 coord);\n"
                       "uint4 _CL_OVERLOADABLE read_imageui (image2d_t image, sampler_t sampler, float2 coord);\n" },
     { "read_imagei", "int4 _CL_OVERLOADABLE read_imagei (image2d_t image, sampler_t sampler, int2 coord);\n"
-                     "int4 _CL_OVERLOADABLE read_imagei (image2d_t image, sampler_t sampler, float2 coord);\n" }
+                     "int4 _CL_OVERLOADABLE read_imagei (image2d_t image, sampler_t sampler, float2 coord);\n" },
+    { "vload2", "_CL_DECLARE_VLOAD_WIDTH(2)\n" },
+    { "vload3", "_CL_DECLARE_VLOAD_WIDTH(3)\n" },
+    { "vload4", "_CL_DECLARE_VLOAD_WIDTH(4)\n" },
+    { "vload8", "_CL_DECLARE_VLOAD_WIDTH(8)\n" },
+    { "vload16", "_CL_DECLARE_VLOAD_WIDTH(16)\n" },
+    { "vstore2", "_CL_DECLARE_VSTORE_WIDTH(2)\n" },
+    { "vstore3", "_CL_DECLARE_VSTORE_WIDTH(3)\n" },
+    { "vstore4", "_CL_DECLARE_VSTORE_WIDTH(4)\n" },
+    { "vstore8", "_CL_DECLARE_VSTORE_WIDTH(8)\n" },
+    { "vstore16", "_CL_DECLARE_VSTORE_WIDTH(16)\n" }
 };
 static const int numBuiltinDecls =
     sizeof(builtinDecls) / sizeof(builtinDecls[0]);

--- a/lib/WebCLBuiltins.hpp
+++ b/lib/WebCLBuiltins.hpp
@@ -26,6 +26,14 @@
 
 #include <set>
 #include <string>
+#include <vector>
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+
+namespace llvm {
+    class raw_ostream;
+}
 
 /// Holds information about OpenCL C builtin functions that require
 /// pointer arguments. The possibly unsafe builtins are partitioned
@@ -50,6 +58,11 @@ public:
     /// at all.
     bool isUnsupported(const std::string &builtin) const;
 
+    /// If the argument is the name of a builtin function not declared
+    /// in kernel.h, emit forward declarations for its overloads
+    // to the output stream; otherwise do nothing
+    void emitDeclarations(llvm::raw_ostream &os, const std::string &builtin);
+
 private:
 
     /// Data structure for builtin function names.
@@ -70,6 +83,15 @@ private:
     /// Calling is always safe for these, even if they have pointer
     /// arguments.
     BuiltinNames safeBuiltins_;
+    /// Known suffixes for the convert_x builtin functions
+    /// (must be in a specific order, so vector used)
+    std::vector<std::string> convertSuffixes_;
+    /// (Sub)set of rounding suffices we have already emitted the incredibly
+    /// expensive _CL_DECLARE_CONVERT_TYPE... macro for
+    BuiltinNames usedConvertSuffixes_;
+    /// Mapping from other known builtin function names to magic macro invocations
+    /// that declare them
+    llvm::StringMap<llvm::SmallVector<const char *, 2> > builtinDecls_;
 };
 
 #endif // WEBCLVALIDATOR_WEBCLBUILTINS

--- a/lib/WebCLBuiltins.hpp
+++ b/lib/WebCLBuiltins.hpp
@@ -83,15 +83,19 @@ private:
     /// Calling is always safe for these, even if they have pointer
     /// arguments.
     BuiltinNames safeBuiltins_;
-    /// Known suffixes for the convert_x builtin functions
+    /// Known rounding suffixes for the convert_x, vstore_x etc builtin functions
     /// (must be in a specific order, so vector used)
-    std::vector<std::string> convertSuffixes_;
-    /// (Sub)set of rounding suffices we have already emitted the incredibly
+    std::vector<std::string> roundingSuffixes_;
+    /// (Sub)set of rounding suffixes we have already emitted the incredibly
     /// expensive _CL_DECLARE_CONVERT_TYPE... macro for
     BuiltinNames usedConvertSuffixes_;
+    /// Ditto for _CL_DECLARE_VSTORE_HALF...
+    BuiltinNames usedVstoreHalfSuffixes_;
     /// Mapping from other known builtin function names to magic macro invocations
     /// that declare them
     llvm::StringMap<llvm::SmallVector<const char *, 2> > builtinDecls_;
+    /// Have the vload_half functions been declared
+    bool vloadHalfDeclared;
 };
 
 #endif // WEBCLVALIDATOR_WEBCLBUILTINS

--- a/lib/WebCLTool.cpp
+++ b/lib/WebCLTool.cpp
@@ -79,7 +79,7 @@ WebCLPreprocessorTool::~WebCLPreprocessorTool()
 
 clang::FrontendAction *WebCLPreprocessorTool::create()
 {
-    WebCLAction *action = new WebCLPreprocessorAction(output_);
+    WebCLAction *action = new WebCLPreprocessorAction(output_, builtinDecls_);
     action->setExtensions(extensions_);
     return action;
 }

--- a/lib/WebCLTool.hpp
+++ b/lib/WebCLTool.hpp
@@ -93,6 +93,14 @@ public:
 
     /// \see clang::tooling::FrontendActionFactory
     virtual clang::FrontendAction *create();
+
+    /// Gets builtin function declarations to include in later stages
+    const std::string &getBuiltinDecls() const { return builtinDecls_; }
+
+private:
+    /// Collects possibly required builtin function declarations to
+    /// be included for later stages
+    std::string builtinDecls_;
 };
 
 /// Runs first stage of AST matcher based transformations. Takes the

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -120,6 +120,9 @@ void WebCLValidator::run()
         return;
     }
 
+    // TODO: augment matcher/validator argv with -Dcl_khr_fp16 etc
+    // based on which extension enable #pragmas have been encountered in preprocessing
+
     /*
      * Feed the builtin declarations produced by the preprocessing stage
      * to be included when running the later stages. This fixes issues

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -120,6 +120,11 @@ void WebCLValidator::run()
         return;
     }
 
+    if (!arguments.supplyBuiltinDecls(preprocessorTool.getBuiltinDecls())) {
+        exitStatus_ = EXIT_FAILURE;
+        return;
+    }
+
     WebCLMatcher1Tool matcher1Tool(matcher1Argc, matcher1Argv,
                                    matcher1Input, matcher2Input);
     matcher1Tool.setExtensions(extensions);

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -120,6 +120,27 @@ void WebCLValidator::run()
         return;
     }
 
+    /*
+     * Feed the builtin declarations produced by the preprocessing stage
+     * to be included when running the later stages. This fixes issues
+     * stemming from builtin functions being assumed to return int by default, etc.
+     *
+     * Not all builtin functions are declared, but only those which the preprocessing
+     * stage detects as possibly having been called by the code being validated.
+     *
+     * TODO: profile, most importantly to see if:
+     *
+     *  1) expanding the _CL_DECLARE... macros takes a significant amount of
+     *     time in the usual cases. In this case, we could capture the preprocessed
+     *     version of the header produced during the first matcher stage and reuse it
+     *     in the remaining matcher and validation stages.
+     *
+     * 2) parsing the literal function declarations produced by macro expansion
+     *    is still expensive. The preprocessing stage can only narrow down the set
+     *    of functions to declare by textual matching; this can provide false positives
+     *    which we could eliminate by looking at the actual function calls in the AST
+     *    once parsed.
+     */
     if (!arguments.supplyBuiltinDecls(preprocessorTool.getBuiltinDecls())) {
         exitStatus_ = EXIT_FAILURE;
         return;

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -1742,6 +1742,9 @@ __IF_FP16(_CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(half));
 _CL_DECLARE_ASYNC_COPY_FUNCS(float);
 __IF_FP64(_CL_DECLARE_ASYNC_COPY_FUNCS(double));
 
+// Fake prefetch declaration to let it be caught more informatively in WebCLAnalyser
+void prefetch(const __global void *, size_t);
+
 // Image support
 
 // Starting from Clang 3.3 the image and sampler are detected

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -473,6 +473,69 @@ __IF_INT64(_CL_DECLARE_AS_TYPE_128(long16))
 __IF_INT64(_CL_DECLARE_AS_TYPE_128(ulong16))
 __IF_FP64(_CL_DECLARE_AS_TYPE_128(double16))
 
+/* Conversions between builtin types.
+ *
+ * Even though the OpenCL specification isn't entirely clear on this
+ * matter, we implement all rounding mode combinations even for
+ * integer-to-integer conversions. The rounding mode is essentially
+ * redundant and thus ignored.
+ *
+ * Other OpenCL implementations seem to allow this in user code, and some
+ * of the test suites/benchmarks out in the wild expect these functions
+ * are available.
+ *
+ * Saturating conversions are only allowed when the destination type
+ * is an integer.
+ */
+
+#define _CL_DECLARE_CONVERT_TYPE(SRC, DST, SIZE, INTSUFFIX, FLOATSUFFIX) \
+  DST##SIZE _CL_OVERLOADABLE                                             \
+  convert_##DST##SIZE##INTSUFFIX##FLOATSUFFIX(SRC##SIZE a);
+
+#define _CL_DECLARE_CONVERT_TYPE_DST(SRC, SIZE, FLOATSUFFIX)            \
+  _CL_DECLARE_CONVERT_TYPE(SRC, char  , SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, char  , SIZE, _sat, FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, uchar , SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, uchar , SIZE, _sat, FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, short , SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, short , SIZE, _sat, FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, ushort, SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, ushort, SIZE, _sat, FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, int   , SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, int   , SIZE, _sat, FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, uint  , SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, uint  , SIZE, _sat, FLOATSUFFIX)        \
+  __IF_INT64(                                                           \
+  _CL_DECLARE_CONVERT_TYPE(SRC, long  , SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, long  , SIZE, _sat, FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, ulong , SIZE,     , FLOATSUFFIX)        \
+  _CL_DECLARE_CONVERT_TYPE(SRC, ulong , SIZE, _sat, FLOATSUFFIX))       \
+  _CL_DECLARE_CONVERT_TYPE(SRC, float , SIZE,     , FLOATSUFFIX)        \
+  __IF_FP64(                                                            \
+  _CL_DECLARE_CONVERT_TYPE(SRC, double, SIZE,     , FLOATSUFFIX))
+
+#define _CL_DECLARE_CONVERT_TYPE_SRC_DST(SIZE, FLOATSUFFIX) \
+  _CL_DECLARE_CONVERT_TYPE_DST(char  , SIZE, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_DST(uchar , SIZE, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_DST(short , SIZE, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_DST(ushort, SIZE, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_DST(int   , SIZE, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_DST(uint  , SIZE, FLOATSUFFIX)   \
+  __IF_INT64(                                               \
+  _CL_DECLARE_CONVERT_TYPE_DST(long  , SIZE, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_DST(ulong , SIZE, FLOATSUFFIX))  \
+  _CL_DECLARE_CONVERT_TYPE_DST(float , SIZE, FLOATSUFFIX)   \
+  __IF_FP64(                                                \
+  _CL_DECLARE_CONVERT_TYPE_DST(double, SIZE, FLOATSUFFIX))
+
+#define _CL_DECLARE_CONVERT_TYPE_SRC_DST_SIZE(FLOATSUFFIX) \
+  _CL_DECLARE_CONVERT_TYPE_SRC_DST(  , FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_SRC_DST( 2, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_SRC_DST( 3, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_SRC_DST( 4, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_SRC_DST( 8, FLOATSUFFIX)   \
+  _CL_DECLARE_CONVERT_TYPE_SRC_DST(16, FLOATSUFFIX)
+
 /* Work-Item Functions */
 
 uint get_work_dim();
@@ -551,6 +614,328 @@ void barrier (cl_mem_fence_flags flags);
 #define M_SQRT1_2  0.707106781186547524400844362105
 #endif
 
+/* Math Functions */
+
+/* Naming scheme:
+ *    [NAME]_[R]_[A]*
+ * where [R] is the return type, and [A] are the argument types:
+ *    I: int
+ *    J: vector of int
+ *    U: vector of uint or ulong
+ *    S: scalar (float or double)
+ *    F: vector of float
+ *    V: vector of float or double
+ */
+
+#define _CL_DECLARE_FUNC_V_V(NAME)              \
+  float    _CL_OVERLOADABLE NAME(float   );     \
+  float2   _CL_OVERLOADABLE NAME(float2  );     \
+  float3   _CL_OVERLOADABLE NAME(float3  );     \
+  float4   _CL_OVERLOADABLE NAME(float4  );     \
+  float8   _CL_OVERLOADABLE NAME(float8  );     \
+  float16  _CL_OVERLOADABLE NAME(float16 );     \
+  __IF_FP64(                                    \
+  double   _CL_OVERLOADABLE NAME(double  );     \
+  double2  _CL_OVERLOADABLE NAME(double2 );     \
+  double3  _CL_OVERLOADABLE NAME(double3 );     \
+  double4  _CL_OVERLOADABLE NAME(double4 );     \
+  double8  _CL_OVERLOADABLE NAME(double8 );     \
+  double16 _CL_OVERLOADABLE NAME(double16);)
+#define _CL_DECLARE_FUNC_V_VV(NAME)                     \
+  float    _CL_OVERLOADABLE NAME(float   , float   );   \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  );   \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  );   \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  );   \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  );   \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 );   \
+  __IF_FP64(                                            \
+  double   _CL_OVERLOADABLE NAME(double  , double  );   \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 );   \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 );   \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 );   \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 );   \
+  double16 _CL_OVERLOADABLE NAME(double16, double16);)
+#define _CL_DECLARE_FUNC_V_VVV(NAME)                                    \
+  float    _CL_OVERLOADABLE NAME(float   , float   , float   );         \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  , float2  );         \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  , float3  );         \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  , float4  );         \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  , float8  );         \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 , float16 );         \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , double  , double  );         \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 , double2 );         \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 , double3 );         \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 , double4 );         \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 , double8 );         \
+  double16 _CL_OVERLOADABLE NAME(double16, double16, double16);)
+#define _CL_DECLARE_FUNC_V_VVS(NAME)                            \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  , float );   \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  , float );   \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  , float );   \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  , float );   \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 , float );   \
+  __IF_FP64(                                                    \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 , double);   \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 , double);   \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 , double);   \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 , double);   \
+  double16 _CL_OVERLOADABLE NAME(double16, double16, double);)
+#define _CL_DECLARE_FUNC_V_VSS(NAME)                            \
+  float2   _CL_OVERLOADABLE NAME(float2  , float , float );     \
+  float3   _CL_OVERLOADABLE NAME(float3  , float , float );     \
+  float4   _CL_OVERLOADABLE NAME(float4  , float , float );     \
+  float8   _CL_OVERLOADABLE NAME(float8  , float , float );     \
+  float16  _CL_OVERLOADABLE NAME(float16 , float , float );     \
+  __IF_FP64(                                                    \
+  double2  _CL_OVERLOADABLE NAME(double2 , double, double);     \
+  double3  _CL_OVERLOADABLE NAME(double3 , double, double);     \
+  double4  _CL_OVERLOADABLE NAME(double4 , double, double);     \
+  double8  _CL_OVERLOADABLE NAME(double8 , double, double);     \
+  double16 _CL_OVERLOADABLE NAME(double16, double, double);)
+#define _CL_DECLARE_FUNC_V_SSV(NAME)                            \
+  float2   _CL_OVERLOADABLE NAME(float , float , float2  );     \
+  float3   _CL_OVERLOADABLE NAME(float , float , float3  );     \
+  float4   _CL_OVERLOADABLE NAME(float , float , float4  );     \
+  float8   _CL_OVERLOADABLE NAME(float , float , float8  );     \
+  float16  _CL_OVERLOADABLE NAME(float , float , float16 );     \
+  __IF_FP64(                                                    \
+  double2  _CL_OVERLOADABLE NAME(double, double, double2 );     \
+  double3  _CL_OVERLOADABLE NAME(double, double, double3 );     \
+  double4  _CL_OVERLOADABLE NAME(double, double, double4 );     \
+  double8  _CL_OVERLOADABLE NAME(double, double, double8 );     \
+  double16 _CL_OVERLOADABLE NAME(double, double, double16);)
+#define _CL_DECLARE_FUNC_V_VVJ(NAME)                                    \
+  __IF_FP16(                                                            \
+  /*half     _CL_OVERLOADABLE NAME(half    , half    , short  );*/      \
+  half2    _CL_OVERLOADABLE NAME(half2   , half2   , short2 );          \
+  half3    _CL_OVERLOADABLE NAME(half3   , half3   , short3 );          \
+  half4    _CL_OVERLOADABLE NAME(half4   , half4   , short4 );          \
+  half8    _CL_OVERLOADABLE NAME(half8   , half8   , short8 );          \
+  half16   _CL_OVERLOADABLE NAME(half16  , half16  , short16);)         \
+  float    _CL_OVERLOADABLE NAME(float   , float   , int    );          \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  , int2   );          \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  , int3   );          \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  , int4   );          \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  , int8   );          \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 , int16  );          \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , double  , long   );          \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 , long2  );          \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 , long3  );          \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 , long4  );          \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 , long8  );          \
+  double16 _CL_OVERLOADABLE NAME(double16, double16, long16 );)
+#define _CL_DECLARE_FUNC_V_VVU(NAME)                                    \
+  __IF_FP16(                                                            \
+  /*half     _CL_OVERLOADABLE NAME(half    , half    , ushort  );*/     \
+  half2    _CL_OVERLOADABLE NAME(half2   , half2   , ushort2 );         \
+  half3    _CL_OVERLOADABLE NAME(half3   , half3   , ushort3 );         \
+  half4    _CL_OVERLOADABLE NAME(half4   , half4   , ushort4 );         \
+  half8    _CL_OVERLOADABLE NAME(half8   , half8   , ushort8 );         \
+  half16   _CL_OVERLOADABLE NAME(half16  , half16  , ushort16);)        \
+  float    _CL_OVERLOADABLE NAME(float   , float   , uint    );         \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  , uint2   );         \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  , uint3   );         \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  , uint4   );         \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  , uint8   );         \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 , uint16  );         \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , double  , ulong   );         \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 , ulong2  );         \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 , ulong3  );         \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 , ulong4  );         \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 , ulong8  );         \
+  double16 _CL_OVERLOADABLE NAME(double16, double16, ulong16 );)
+#define _CL_DECLARE_FUNC_V_U(NAME)              \
+  float    _CL_OVERLOADABLE NAME(uint   );      \
+  float2   _CL_OVERLOADABLE NAME(uint2  );      \
+  float3   _CL_OVERLOADABLE NAME(uint3  );      \
+  float4   _CL_OVERLOADABLE NAME(uint4  );      \
+  float8   _CL_OVERLOADABLE NAME(uint8  );      \
+  float16  _CL_OVERLOADABLE NAME(uint16 );      \
+  __IF_FP64(                                    \
+  double   _CL_OVERLOADABLE NAME(ulong  );      \
+  double2  _CL_OVERLOADABLE NAME(ulong2 );      \
+  double3  _CL_OVERLOADABLE NAME(ulong3 );      \
+  double4  _CL_OVERLOADABLE NAME(ulong4 );      \
+  double8  _CL_OVERLOADABLE NAME(ulong8 );      \
+  double16 _CL_OVERLOADABLE NAME(ulong16);)
+#define _CL_DECLARE_FUNC_V_VS(NAME)                     \
+  float2   _CL_OVERLOADABLE NAME(float2  , float );     \
+  float3   _CL_OVERLOADABLE NAME(float3  , float );     \
+  float4   _CL_OVERLOADABLE NAME(float4  , float );     \
+  float8   _CL_OVERLOADABLE NAME(float8  , float );     \
+  float16  _CL_OVERLOADABLE NAME(float16 , float );     \
+  __IF_FP64(                                            \
+  double2  _CL_OVERLOADABLE NAME(double2 , double);     \
+  double3  _CL_OVERLOADABLE NAME(double3 , double);     \
+  double4  _CL_OVERLOADABLE NAME(double4 , double);     \
+  double8  _CL_OVERLOADABLE NAME(double8 , double);     \
+  double16 _CL_OVERLOADABLE NAME(double16, double);)
+#define _CL_DECLARE_FUNC_V_VJ(NAME)                     \
+  float    _CL_OVERLOADABLE NAME(float   , int  );      \
+  float2   _CL_OVERLOADABLE NAME(float2  , int2 );      \
+  float3   _CL_OVERLOADABLE NAME(float3  , int3 );      \
+  float4   _CL_OVERLOADABLE NAME(float4  , int4 );      \
+  float8   _CL_OVERLOADABLE NAME(float8  , int8 );      \
+  float16  _CL_OVERLOADABLE NAME(float16 , int16);      \
+  __IF_FP64(                                            \
+  double   _CL_OVERLOADABLE NAME(double  , int  );      \
+  double2  _CL_OVERLOADABLE NAME(double2 , int2 );      \
+  double3  _CL_OVERLOADABLE NAME(double3 , int3 );      \
+  double4  _CL_OVERLOADABLE NAME(double4 , int4 );      \
+  double8  _CL_OVERLOADABLE NAME(double8 , int8 );      \
+  double16 _CL_OVERLOADABLE NAME(double16, int16);)
+#define _CL_DECLARE_FUNC_J_VV(NAME)                     \
+  int    _CL_OVERLOADABLE NAME(float   , float   );     \
+  int2   _CL_OVERLOADABLE NAME(float2  , float2  );     \
+  int3   _CL_OVERLOADABLE NAME(float3  , float3  );     \
+  int4   _CL_OVERLOADABLE NAME(float4  , float4  );     \
+  int8   _CL_OVERLOADABLE NAME(float8  , float8  );     \
+  int16  _CL_OVERLOADABLE NAME(float16 , float16 );     \
+  __IF_FP64(                                            \
+  int    _CL_OVERLOADABLE NAME(double  , double  );     \
+  long2  _CL_OVERLOADABLE NAME(double2 , double2 );     \
+  long3  _CL_OVERLOADABLE NAME(double3 , double3 );     \
+  long4  _CL_OVERLOADABLE NAME(double4 , double4 );     \
+  long8  _CL_OVERLOADABLE NAME(double8 , double8 );     \
+  long16 _CL_OVERLOADABLE NAME(double16, double16);)
+#define _CL_DECLARE_FUNC_V_VI(NAME)                     \
+  float2   _CL_OVERLOADABLE NAME(float2  , int);        \
+  float3   _CL_OVERLOADABLE NAME(float3  , int);        \
+  float4   _CL_OVERLOADABLE NAME(float4  , int);        \
+  float8   _CL_OVERLOADABLE NAME(float8  , int);        \
+  float16  _CL_OVERLOADABLE NAME(float16 , int);        \
+  __IF_FP64(                                            \
+  double2  _CL_OVERLOADABLE NAME(double2 , int);        \
+  double3  _CL_OVERLOADABLE NAME(double3 , int);        \
+  double4  _CL_OVERLOADABLE NAME(double4 , int);        \
+  double8  _CL_OVERLOADABLE NAME(double8 , int);        \
+  double16 _CL_OVERLOADABLE NAME(double16, int);)
+#define _CL_DECLARE_FUNC_V_VPV(NAME)                                    \
+  float    _CL_OVERLOADABLE NAME(float   , __global  float   *);        \
+  float2   _CL_OVERLOADABLE NAME(float2  , __global  float2  *);        \
+  float3   _CL_OVERLOADABLE NAME(float3  , __global  float3  *);        \
+  float4   _CL_OVERLOADABLE NAME(float4  , __global  float4  *);        \
+  float8   _CL_OVERLOADABLE NAME(float8  , __global  float8  *);        \
+  float16  _CL_OVERLOADABLE NAME(float16 , __global  float16 *);        \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , __global  double  *);        \
+  double2  _CL_OVERLOADABLE NAME(double2 , __global  double2 *);        \
+  double3  _CL_OVERLOADABLE NAME(double3 , __global  double3 *);        \
+  double4  _CL_OVERLOADABLE NAME(double4 , __global  double4 *);        \
+  double8  _CL_OVERLOADABLE NAME(double8 , __global  double8 *);        \
+  double16 _CL_OVERLOADABLE NAME(double16, __global  double16*);)       \
+  float    _CL_OVERLOADABLE NAME(float   , __local   float   *);        \
+  float2   _CL_OVERLOADABLE NAME(float2  , __local   float2  *);        \
+  float3   _CL_OVERLOADABLE NAME(float3  , __local   float3  *);        \
+  float4   _CL_OVERLOADABLE NAME(float4  , __local   float4  *);        \
+  float8   _CL_OVERLOADABLE NAME(float8  , __local   float8  *);        \
+  float16  _CL_OVERLOADABLE NAME(float16 , __local   float16 *);        \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , __local   double  *);        \
+  double2  _CL_OVERLOADABLE NAME(double2 , __local   double2 *);        \
+  double3  _CL_OVERLOADABLE NAME(double3 , __local   double3 *);        \
+  double4  _CL_OVERLOADABLE NAME(double4 , __local   double4 *);        \
+  double8  _CL_OVERLOADABLE NAME(double8 , __local   double8 *);        \
+  double16 _CL_OVERLOADABLE NAME(double16, __local   double16*);)       \
+  float    _CL_OVERLOADABLE NAME(float   , __private float   *);        \
+  float2   _CL_OVERLOADABLE NAME(float2  , __private float2  *);        \
+  float3   _CL_OVERLOADABLE NAME(float3  , __private float3  *);        \
+  float4   _CL_OVERLOADABLE NAME(float4  , __private float4  *);        \
+  float8   _CL_OVERLOADABLE NAME(float8  , __private float8  *);        \
+  float16  _CL_OVERLOADABLE NAME(float16 , __private float16 *);        \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , __private double  *);        \
+  double2  _CL_OVERLOADABLE NAME(double2 , __private double2 *);        \
+  double3  _CL_OVERLOADABLE NAME(double3 , __private double3 *);        \
+  double4  _CL_OVERLOADABLE NAME(double4 , __private double4 *);        \
+  double8  _CL_OVERLOADABLE NAME(double8 , __private double8 *);        \
+  double16 _CL_OVERLOADABLE NAME(double16, __private double16*);)
+#define _CL_DECLARE_FUNC_V_SV(NAME)                     \
+  float2   _CL_OVERLOADABLE NAME(float , float2  );     \
+  float3   _CL_OVERLOADABLE NAME(float , float3  );     \
+  float4   _CL_OVERLOADABLE NAME(float , float4  );     \
+  float8   _CL_OVERLOADABLE NAME(float , float8  );     \
+  float16  _CL_OVERLOADABLE NAME(float , float16 );     \
+  __IF_FP64(                                            \
+  double2  _CL_OVERLOADABLE NAME(double, double2 );     \
+  double3  _CL_OVERLOADABLE NAME(double, double3 );     \
+  double4  _CL_OVERLOADABLE NAME(double, double4 );     \
+  double8  _CL_OVERLOADABLE NAME(double, double8 );     \
+  double16 _CL_OVERLOADABLE NAME(double, double16);)
+#define _CL_DECLARE_FUNC_J_V(NAME)              \
+  int   _CL_OVERLOADABLE NAME(float   );        \
+  int2  _CL_OVERLOADABLE NAME(float2  );        \
+  int3  _CL_OVERLOADABLE NAME(float3  );        \
+  int4  _CL_OVERLOADABLE NAME(float4  );        \
+  int8  _CL_OVERLOADABLE NAME(float8  );        \
+  int16 _CL_OVERLOADABLE NAME(float16 );        \
+  __IF_FP64(                                    \
+  int    _CL_OVERLOADABLE NAME(double  );       \
+  long2  _CL_OVERLOADABLE NAME(double2 );       \
+  long3  _CL_OVERLOADABLE NAME(double3 );       \
+  long4  _CL_OVERLOADABLE NAME(double4 );       \
+  long8  _CL_OVERLOADABLE NAME(double8 );       \
+  long16 _CL_OVERLOADABLE NAME(double16);)
+#define _CL_DECLARE_FUNC_K_V(NAME)              \
+  int   _CL_OVERLOADABLE NAME(float   );        \
+  int2  _CL_OVERLOADABLE NAME(float2  );        \
+  int3  _CL_OVERLOADABLE NAME(float3  );        \
+  int4  _CL_OVERLOADABLE NAME(float4  );        \
+  int8  _CL_OVERLOADABLE NAME(float8  );        \
+  int16 _CL_OVERLOADABLE NAME(float16 );        \
+  __IF_FP64(                                    \
+  int   _CL_OVERLOADABLE NAME(double  );        \
+  int2  _CL_OVERLOADABLE NAME(double2 );        \
+  int3  _CL_OVERLOADABLE NAME(double3 );        \
+  int4  _CL_OVERLOADABLE NAME(double4 );        \
+  int8  _CL_OVERLOADABLE NAME(double8 );        \
+  int16 _CL_OVERLOADABLE NAME(double16);)
+#define _CL_DECLARE_FUNC_S_V(NAME)              \
+  float  _CL_OVERLOADABLE NAME(float   );       \
+  float  _CL_OVERLOADABLE NAME(float2  );       \
+  float  _CL_OVERLOADABLE NAME(float3  );       \
+  float  _CL_OVERLOADABLE NAME(float4  );       \
+  float  _CL_OVERLOADABLE NAME(float8  );       \
+  float  _CL_OVERLOADABLE NAME(float16 );       \
+  __IF_FP64(                                    \
+  double _CL_OVERLOADABLE NAME(double  );       \
+  double _CL_OVERLOADABLE NAME(double2 );       \
+  double _CL_OVERLOADABLE NAME(double3 );       \
+  double _CL_OVERLOADABLE NAME(double4 );       \
+  double _CL_OVERLOADABLE NAME(double8 );       \
+  double _CL_OVERLOADABLE NAME(double16);)
+#define _CL_DECLARE_FUNC_S_VV(NAME)                     \
+  float  _CL_OVERLOADABLE NAME(float   , float   );     \
+  float  _CL_OVERLOADABLE NAME(float2  , float2  );     \
+  float  _CL_OVERLOADABLE NAME(float3  , float3  );     \
+  float  _CL_OVERLOADABLE NAME(float4  , float4  );     \
+  float  _CL_OVERLOADABLE NAME(float8  , float8  );     \
+  float  _CL_OVERLOADABLE NAME(float16 , float16 );     \
+  __IF_FP64(                                            \
+  double _CL_OVERLOADABLE NAME(double  , double  );     \
+  double _CL_OVERLOADABLE NAME(double2 , double2 );     \
+  double _CL_OVERLOADABLE NAME(double3 , double3 );     \
+  double _CL_OVERLOADABLE NAME(double4 , double4 );     \
+  double _CL_OVERLOADABLE NAME(double8 , double8 );     \
+  double _CL_OVERLOADABLE NAME(double16, double16);)
+#define _CL_DECLARE_FUNC_F_F(NAME)              \
+  float    _CL_OVERLOADABLE NAME(float   );     \
+  float2   _CL_OVERLOADABLE NAME(float2  );     \
+  float3   _CL_OVERLOADABLE NAME(float3  );     \
+  float4   _CL_OVERLOADABLE NAME(float4  );     \
+  float8   _CL_OVERLOADABLE NAME(float8  );     \
+  float16  _CL_OVERLOADABLE NAME(float16 );
+#define _CL_DECLARE_FUNC_F_FF(NAME)                     \
+  float    _CL_OVERLOADABLE NAME(float   , float   );   \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  );   \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  );   \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  );   \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  );   \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 );
+
 /* Integer Constants */
 
 #define CHAR_BIT  8
@@ -572,6 +957,492 @@ void barrier (cl_mem_fence_flags flags);
 #ifdef cles_khr_int64
 #define ULONG_MAX 0xffffffffffffffffUL
 #endif
+
+/* Integer Functions */
+#define _CL_DECLARE_FUNC_G_G(NAME)              \
+  char     _CL_OVERLOADABLE NAME(char    );     \
+  char2    _CL_OVERLOADABLE NAME(char2   );     \
+  char3    _CL_OVERLOADABLE NAME(char3   );     \
+  char4    _CL_OVERLOADABLE NAME(char4   );     \
+  char8    _CL_OVERLOADABLE NAME(char8   );     \
+  char16   _CL_OVERLOADABLE NAME(char16  );     \
+  uchar    _CL_OVERLOADABLE NAME(uchar   );     \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  );     \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  );     \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  );     \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  );     \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 );     \
+  short    _CL_OVERLOADABLE NAME(short   );     \
+  short2   _CL_OVERLOADABLE NAME(short2  );     \
+  short3   _CL_OVERLOADABLE NAME(short3  );     \
+  short4   _CL_OVERLOADABLE NAME(short4  );     \
+  short8   _CL_OVERLOADABLE NAME(short8  );     \
+  short16  _CL_OVERLOADABLE NAME(short16 );     \
+  ushort   _CL_OVERLOADABLE NAME(ushort  );     \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 );     \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 );     \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 );     \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 );     \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16);     \
+  int      _CL_OVERLOADABLE NAME(int     );     \
+  int2     _CL_OVERLOADABLE NAME(int2    );     \
+  int3     _CL_OVERLOADABLE NAME(int3    );     \
+  int4     _CL_OVERLOADABLE NAME(int4    );     \
+  int8     _CL_OVERLOADABLE NAME(int8    );     \
+  int16    _CL_OVERLOADABLE NAME(int16   );     \
+  uint     _CL_OVERLOADABLE NAME(uint    );     \
+  uint2    _CL_OVERLOADABLE NAME(uint2   );     \
+  uint3    _CL_OVERLOADABLE NAME(uint3   );     \
+  uint4    _CL_OVERLOADABLE NAME(uint4   );     \
+  uint8    _CL_OVERLOADABLE NAME(uint8   );     \
+  uint16   _CL_OVERLOADABLE NAME(uint16  );     \
+  __IF_INT64(                                   \
+  long     _CL_OVERLOADABLE NAME(long    );     \
+  long2    _CL_OVERLOADABLE NAME(long2   );     \
+  long3    _CL_OVERLOADABLE NAME(long3   );     \
+  long4    _CL_OVERLOADABLE NAME(long4   );     \
+  long8    _CL_OVERLOADABLE NAME(long8   );     \
+  long16   _CL_OVERLOADABLE NAME(long16  );     \
+  ulong    _CL_OVERLOADABLE NAME(ulong   );     \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  );     \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  );     \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  );     \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  );     \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 );)
+#define _CL_DECLARE_FUNC_G_GG(NAME)                     \
+  char     _CL_OVERLOADABLE NAME(char    , char    );   \
+  char2    _CL_OVERLOADABLE NAME(char2   , char2   );   \
+  char3    _CL_OVERLOADABLE NAME(char3   , char3   );   \
+  char4    _CL_OVERLOADABLE NAME(char4   , char4   );   \
+  char8    _CL_OVERLOADABLE NAME(char8   , char8   );   \
+  char16   _CL_OVERLOADABLE NAME(char16  , char16  );   \
+  uchar    _CL_OVERLOADABLE NAME(uchar   , uchar   );   \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  , uchar2  );   \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  , uchar3  );   \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  , uchar4  );   \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  , uchar8  );   \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 , uchar16 );   \
+  short    _CL_OVERLOADABLE NAME(short   , short   );   \
+  short2   _CL_OVERLOADABLE NAME(short2  , short2  );   \
+  short3   _CL_OVERLOADABLE NAME(short3  , short3  );   \
+  short4   _CL_OVERLOADABLE NAME(short4  , short4  );   \
+  short8   _CL_OVERLOADABLE NAME(short8  , short8  );   \
+  short16  _CL_OVERLOADABLE NAME(short16 , short16 );   \
+  ushort   _CL_OVERLOADABLE NAME(ushort  , ushort  );   \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 , ushort2 );   \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 , ushort3 );   \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 , ushort4 );   \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 , ushort8 );   \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16, ushort16);   \
+  int      _CL_OVERLOADABLE NAME(int     , int     );   \
+  int2     _CL_OVERLOADABLE NAME(int2    , int2    );   \
+  int3     _CL_OVERLOADABLE NAME(int3    , int3    );   \
+  int4     _CL_OVERLOADABLE NAME(int4    , int4    );   \
+  int8     _CL_OVERLOADABLE NAME(int8    , int8    );   \
+  int16    _CL_OVERLOADABLE NAME(int16   , int16   );   \
+  uint     _CL_OVERLOADABLE NAME(uint    , uint    );   \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint2   );   \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint3   );   \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint4   );   \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   );   \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  );   \
+  __IF_INT64(                                           \
+  long     _CL_OVERLOADABLE NAME(long    , long    );   \
+  long2    _CL_OVERLOADABLE NAME(long2   , long2   );   \
+  long3    _CL_OVERLOADABLE NAME(long3   , long3   );   \
+  long4    _CL_OVERLOADABLE NAME(long4   , long4   );   \
+  long8    _CL_OVERLOADABLE NAME(long8   , long8   );   \
+  long16   _CL_OVERLOADABLE NAME(long16  , long16  );   \
+  ulong    _CL_OVERLOADABLE NAME(ulong   , ulong   );   \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  , ulong2  );   \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  , ulong3  );   \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  , ulong4  );   \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  , ulong8  );   \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 , ulong16 );)
+#define _CL_DECLARE_FUNC_G_GGG(NAME)                            \
+  char     _CL_OVERLOADABLE NAME(char    , char    , char    ); \
+  char2    _CL_OVERLOADABLE NAME(char2   , char2   , char2   ); \
+  char3    _CL_OVERLOADABLE NAME(char3   , char3   , char3   ); \
+  char4    _CL_OVERLOADABLE NAME(char4   , char4   , char4   ); \
+  char8    _CL_OVERLOADABLE NAME(char8   , char8   , char8   ); \
+  char16   _CL_OVERLOADABLE NAME(char16  , char16  , char16  ); \
+  uchar    _CL_OVERLOADABLE NAME(uchar   , uchar   , uchar   ); \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  , uchar2  , uchar2  ); \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  , uchar3  , uchar3  ); \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  , uchar4  , uchar4  ); \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  , uchar8  , uchar8  ); \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 , uchar16 , uchar16 ); \
+  short    _CL_OVERLOADABLE NAME(short   , short   , short   ); \
+  short2   _CL_OVERLOADABLE NAME(short2  , short2  , short2  ); \
+  short3   _CL_OVERLOADABLE NAME(short3  , short3  , short3  ); \
+  short4   _CL_OVERLOADABLE NAME(short4  , short4  , short4  ); \
+  short8   _CL_OVERLOADABLE NAME(short8  , short8  , short8  ); \
+  short16  _CL_OVERLOADABLE NAME(short16 , short16 , short16 ); \
+  ushort   _CL_OVERLOADABLE NAME(ushort  , ushort  , ushort  ); \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 , ushort2 , ushort2 ); \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 , ushort3 , ushort3 ); \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 , ushort4 , ushort4 ); \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 , ushort8 , ushort8 ); \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16, ushort16, ushort16); \
+  int      _CL_OVERLOADABLE NAME(int     , int     , int     ); \
+  int2     _CL_OVERLOADABLE NAME(int2    , int2    , int2    ); \
+  int3     _CL_OVERLOADABLE NAME(int3    , int3    , int3    ); \
+  int4     _CL_OVERLOADABLE NAME(int4    , int4    , int4    ); \
+  int8     _CL_OVERLOADABLE NAME(int8    , int8    , int8    ); \
+  int16    _CL_OVERLOADABLE NAME(int16   , int16   , int16   ); \
+  uint     _CL_OVERLOADABLE NAME(uint    , uint    , uint    ); \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint2   , uint2   ); \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint3   , uint3   ); \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint4   , uint4   ); \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   , uint8   ); \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  , uint16  ); \
+  __IF_INT64(                                                   \
+  long     _CL_OVERLOADABLE NAME(long    , long    , long    ); \
+  long2    _CL_OVERLOADABLE NAME(long2   , long2   , long2   ); \
+  long3    _CL_OVERLOADABLE NAME(long3   , long3   , long3   ); \
+  long4    _CL_OVERLOADABLE NAME(long4   , long4   , long4   ); \
+  long8    _CL_OVERLOADABLE NAME(long8   , long8   , long8   ); \
+  long16   _CL_OVERLOADABLE NAME(long16  , long16  , long16  ); \
+  ulong    _CL_OVERLOADABLE NAME(ulong   , ulong   , ulong   ); \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  , ulong2  , ulong2  ); \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  , ulong3  , ulong3  ); \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  , ulong4  , ulong4  ); \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  , ulong8  , ulong8  ); \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 , ulong16 , ulong16 );)
+#define _CL_DECLARE_FUNC_G_GGIG(NAME)                                   \
+  char     _CL_OVERLOADABLE NAME(char    , char    , char    );         \
+  char2    _CL_OVERLOADABLE NAME(char2   , char2   , char2   );         \
+  char3    _CL_OVERLOADABLE NAME(char3   , char3   , char3   );         \
+  char4    _CL_OVERLOADABLE NAME(char4   , char4   , char4   );         \
+  char8    _CL_OVERLOADABLE NAME(char8   , char8   , char8   );         \
+  char16   _CL_OVERLOADABLE NAME(char16  , char16  , char16  );         \
+  uchar    _CL_OVERLOADABLE NAME(uchar   , uchar   , char    );         \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  , uchar2  , char2   );         \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  , uchar3  , char3   );         \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  , uchar4  , char4   );         \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  , uchar8  , char8   );         \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 , uchar16 , char16  );         \
+  short    _CL_OVERLOADABLE NAME(short   , short   , short   );         \
+  short2   _CL_OVERLOADABLE NAME(short2  , short2  , short2  );         \
+  short3   _CL_OVERLOADABLE NAME(short3  , short3  , short3  );         \
+  short4   _CL_OVERLOADABLE NAME(short4  , short4  , short4  );         \
+  short8   _CL_OVERLOADABLE NAME(short8  , short8  , short8  );         \
+  short16  _CL_OVERLOADABLE NAME(short16 , short16 , short16 );         \
+  ushort   _CL_OVERLOADABLE NAME(ushort  , ushort  , short   );         \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 , ushort2 , short2  );         \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 , ushort3 , short3  );         \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 , ushort4 , short4  );         \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 , ushort8 , short8  );         \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16, ushort16, short16 );         \
+  int      _CL_OVERLOADABLE NAME(int     , int     , int     );         \
+  int2     _CL_OVERLOADABLE NAME(int2    , int2    , int2    );         \
+  int3     _CL_OVERLOADABLE NAME(int3    , int3    , int3    );         \
+  int4     _CL_OVERLOADABLE NAME(int4    , int4    , int4    );         \
+  int8     _CL_OVERLOADABLE NAME(int8    , int8    , int8    );         \
+  int16    _CL_OVERLOADABLE NAME(int16   , int16   , int16   );         \
+  uint     _CL_OVERLOADABLE NAME(uint    , uint    , int     );         \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint2   , int2    );         \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint3   , int3    );         \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint4   , int4    );         \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   , int8    );         \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  , int16   );         \
+  __IF_INT64(                                                           \
+  long     _CL_OVERLOADABLE NAME(long    , long    , long    );         \
+  long2    _CL_OVERLOADABLE NAME(long2   , long2   , long2   );         \
+  long3    _CL_OVERLOADABLE NAME(long3   , long3   , long3   );         \
+  long4    _CL_OVERLOADABLE NAME(long4   , long4   , long4   );         \
+  long8    _CL_OVERLOADABLE NAME(long8   , long8   , long8   );         \
+  long16   _CL_OVERLOADABLE NAME(long16  , long16  , long16  );         \
+  ulong    _CL_OVERLOADABLE NAME(ulong   , ulong   , long    );         \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  , ulong2  , long2   );         \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  , ulong3  , long3   );         \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  , ulong4  , long4   );         \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  , ulong8  , long8   );         \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 , ulong16 , long16  );)
+#define _CL_DECLARE_FUNC_G_GGUG(NAME)                                   \
+  char     _CL_OVERLOADABLE NAME(char    , char    , uchar    );        \
+  char2    _CL_OVERLOADABLE NAME(char2   , char2   , uchar2   );        \
+  char3    _CL_OVERLOADABLE NAME(char3   , char3   , uchar3   );        \
+  char4    _CL_OVERLOADABLE NAME(char4   , char4   , uchar4   );        \
+  char8    _CL_OVERLOADABLE NAME(char8   , char8   , uchar8   );        \
+  char16   _CL_OVERLOADABLE NAME(char16  , char16  , uchar16  );        \
+  uchar    _CL_OVERLOADABLE NAME(uchar   , uchar   , uchar    );        \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  , uchar2  , uchar2   );        \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  , uchar3  , uchar3   );        \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  , uchar4  , uchar4   );        \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  , uchar8  , uchar8   );        \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 , uchar16 , uchar16  );        \
+  short    _CL_OVERLOADABLE NAME(short   , short   , ushort   );        \
+  short2   _CL_OVERLOADABLE NAME(short2  , short2  , ushort2  );        \
+  short3   _CL_OVERLOADABLE NAME(short3  , short3  , ushort3  );        \
+  short4   _CL_OVERLOADABLE NAME(short4  , short4  , ushort4  );        \
+  short8   _CL_OVERLOADABLE NAME(short8  , short8  , ushort8  );        \
+  short16  _CL_OVERLOADABLE NAME(short16 , short16 , ushort16 );        \
+  ushort   _CL_OVERLOADABLE NAME(ushort  , ushort  , ushort   );        \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 , ushort2 , ushort2  );        \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 , ushort3 , ushort3  );        \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 , ushort4 , ushort4  );        \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 , ushort8 , ushort8  );        \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16, ushort16, ushort16 );        \
+  int      _CL_OVERLOADABLE NAME(int     , int     , uint     );        \
+  int2     _CL_OVERLOADABLE NAME(int2    , int2    , uint2    );        \
+  int3     _CL_OVERLOADABLE NAME(int3    , int3    , uint3    );        \
+  int4     _CL_OVERLOADABLE NAME(int4    , int4    , uint4    );        \
+  int8     _CL_OVERLOADABLE NAME(int8    , int8    , uint8    );        \
+  int16    _CL_OVERLOADABLE NAME(int16   , int16   , uint16   );        \
+  uint     _CL_OVERLOADABLE NAME(uint    , uint    , uint     );        \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint2   , uint2    );        \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint3   , uint3    );        \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint4   , uint4    );        \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   , uint8    );        \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  , uint16   );        \
+  __IF_INT64(                                                           \
+  long     _CL_OVERLOADABLE NAME(long    , long    , ulong    );        \
+  long2    _CL_OVERLOADABLE NAME(long2   , long2   , ulong2   );        \
+  long3    _CL_OVERLOADABLE NAME(long3   , long3   , ulong3   );        \
+  long4    _CL_OVERLOADABLE NAME(long4   , long4   , ulong4   );        \
+  long8    _CL_OVERLOADABLE NAME(long8   , long8   , ulong8   );        \
+  long16   _CL_OVERLOADABLE NAME(long16  , long16  , ulong16  );        \
+  ulong    _CL_OVERLOADABLE NAME(ulong   , ulong   , ulong    );        \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  , ulong2  , ulong2   );        \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  , ulong3  , ulong3   );        \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  , ulong4  , ulong4   );        \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  , ulong8  , ulong8   );        \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 , ulong16 , ulong16  );)
+#define _CL_DECLARE_FUNC_G_GS(NAME)                     \
+  char2    _CL_OVERLOADABLE NAME(char2   , char  );     \
+  char3    _CL_OVERLOADABLE NAME(char3   , char  );     \
+  char4    _CL_OVERLOADABLE NAME(char4   , char  );     \
+  char8    _CL_OVERLOADABLE NAME(char8   , char  );     \
+  char16   _CL_OVERLOADABLE NAME(char16  , char  );     \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  , uchar );     \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  , uchar );     \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  , uchar );     \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  , uchar );     \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 , uchar );     \
+  short2   _CL_OVERLOADABLE NAME(short2  , short );     \
+  short3   _CL_OVERLOADABLE NAME(short3  , short );     \
+  short4   _CL_OVERLOADABLE NAME(short4  , short );     \
+  short8   _CL_OVERLOADABLE NAME(short8  , short );     \
+  short16  _CL_OVERLOADABLE NAME(short16 , short );     \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 , ushort);     \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 , ushort);     \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 , ushort);     \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 , ushort);     \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16, ushort);     \
+  int2     _CL_OVERLOADABLE NAME(int2    , int   );     \
+  int3     _CL_OVERLOADABLE NAME(int3    , int   );     \
+  int4     _CL_OVERLOADABLE NAME(int4    , int   );     \
+  int8     _CL_OVERLOADABLE NAME(int8    , int   );     \
+  int16    _CL_OVERLOADABLE NAME(int16   , int   );     \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint  );     \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint  );     \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint  );     \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint  );     \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint  );     \
+  __IF_INT64(                                           \
+  long2    _CL_OVERLOADABLE NAME(long2   , long  );     \
+  long3    _CL_OVERLOADABLE NAME(long3   , long  );     \
+  long4    _CL_OVERLOADABLE NAME(long4   , long  );     \
+  long8    _CL_OVERLOADABLE NAME(long8   , long  );     \
+  long16   _CL_OVERLOADABLE NAME(long16  , long  );     \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  , ulong );     \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  , ulong );     \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  , ulong );     \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  , ulong );     \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 , ulong );)
+#define _CL_DECLARE_FUNC_UG_G(NAME)             \
+  uchar    _CL_OVERLOADABLE NAME(char    );     \
+  uchar2   _CL_OVERLOADABLE NAME(char2   );     \
+  uchar3   _CL_OVERLOADABLE NAME(char3   );     \
+  uchar4   _CL_OVERLOADABLE NAME(char4   );     \
+  uchar8   _CL_OVERLOADABLE NAME(char8   );     \
+  uchar16  _CL_OVERLOADABLE NAME(char16  );     \
+  ushort   _CL_OVERLOADABLE NAME(short   );     \
+  ushort2  _CL_OVERLOADABLE NAME(short2  );     \
+  ushort3  _CL_OVERLOADABLE NAME(short3  );     \
+  ushort4  _CL_OVERLOADABLE NAME(short4  );     \
+  ushort8  _CL_OVERLOADABLE NAME(short8  );     \
+  ushort16 _CL_OVERLOADABLE NAME(short16 );     \
+  uint     _CL_OVERLOADABLE NAME(int     );     \
+  uint2    _CL_OVERLOADABLE NAME(int2    );     \
+  uint3    _CL_OVERLOADABLE NAME(int3    );     \
+  uint4    _CL_OVERLOADABLE NAME(int4    );     \
+  uint8    _CL_OVERLOADABLE NAME(int8    );     \
+  uint16   _CL_OVERLOADABLE NAME(int16   );     \
+  __IF_INT64(                                   \
+  ulong    _CL_OVERLOADABLE NAME(long    );     \
+  ulong2   _CL_OVERLOADABLE NAME(long2   );     \
+  ulong3   _CL_OVERLOADABLE NAME(long3   );     \
+  ulong4   _CL_OVERLOADABLE NAME(long4   );     \
+  ulong8   _CL_OVERLOADABLE NAME(long8   );     \
+  ulong16  _CL_OVERLOADABLE NAME(long16  );)    \
+  uchar    _CL_OVERLOADABLE NAME(uchar   );     \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  );     \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  );     \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  );     \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  );     \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 );     \
+  ushort   _CL_OVERLOADABLE NAME(ushort  );     \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 );     \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 );     \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 );     \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 );     \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16);     \
+  uint     _CL_OVERLOADABLE NAME(uint    );     \
+  uint2    _CL_OVERLOADABLE NAME(uint2   );     \
+  uint3    _CL_OVERLOADABLE NAME(uint3   );     \
+  uint4    _CL_OVERLOADABLE NAME(uint4   );     \
+  uint8    _CL_OVERLOADABLE NAME(uint8   );     \
+  uint16   _CL_OVERLOADABLE NAME(uint16  );     \
+  __IF_INT64(                                   \
+  ulong    _CL_OVERLOADABLE NAME(ulong   );     \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  );     \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  );     \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  );     \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  );     \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 );)
+#define _CL_DECLARE_FUNC_UG_GG(NAME)                    \
+  uchar    _CL_OVERLOADABLE NAME(char    , char    );   \
+  uchar2   _CL_OVERLOADABLE NAME(char2   , char2   );   \
+  uchar3   _CL_OVERLOADABLE NAME(char3   , char3   );   \
+  uchar4   _CL_OVERLOADABLE NAME(char4   , char4   );   \
+  uchar8   _CL_OVERLOADABLE NAME(char8   , char8   );   \
+  uchar16  _CL_OVERLOADABLE NAME(char16  , char16  );   \
+  ushort   _CL_OVERLOADABLE NAME(short   , short   );   \
+  ushort2  _CL_OVERLOADABLE NAME(short2  , short2  );   \
+  ushort3  _CL_OVERLOADABLE NAME(short3  , short3  );   \
+  ushort4  _CL_OVERLOADABLE NAME(short4  , short4  );   \
+  ushort8  _CL_OVERLOADABLE NAME(short8  , short8  );   \
+  ushort16 _CL_OVERLOADABLE NAME(short16 , short16 );   \
+  uint     _CL_OVERLOADABLE NAME(int     , int     );   \
+  uint2    _CL_OVERLOADABLE NAME(int2    , int2    );   \
+  uint3    _CL_OVERLOADABLE NAME(int3    , int3    );   \
+  uint4    _CL_OVERLOADABLE NAME(int4    , int4    );   \
+  uint8    _CL_OVERLOADABLE NAME(int8    , int8    );   \
+  uint16   _CL_OVERLOADABLE NAME(int16   , int16   );   \
+  __IF_INT64(                                           \
+  ulong    _CL_OVERLOADABLE NAME(long    , long    );   \
+  ulong2   _CL_OVERLOADABLE NAME(long2   , long2   );   \
+  ulong3   _CL_OVERLOADABLE NAME(long3   , long3   );   \
+  ulong4   _CL_OVERLOADABLE NAME(long4   , long4   );   \
+  ulong8   _CL_OVERLOADABLE NAME(long8   , long8   );   \
+  ulong16  _CL_OVERLOADABLE NAME(long16  , long16  );)  \
+  uchar    _CL_OVERLOADABLE NAME(uchar   , uchar   );   \
+  uchar2   _CL_OVERLOADABLE NAME(uchar2  , uchar2  );   \
+  uchar3   _CL_OVERLOADABLE NAME(uchar3  , uchar3  );   \
+  uchar4   _CL_OVERLOADABLE NAME(uchar4  , uchar4  );   \
+  uchar8   _CL_OVERLOADABLE NAME(uchar8  , uchar8  );   \
+  uchar16  _CL_OVERLOADABLE NAME(uchar16 , uchar16 );   \
+  ushort   _CL_OVERLOADABLE NAME(ushort  , ushort  );   \
+  ushort2  _CL_OVERLOADABLE NAME(ushort2 , ushort2 );   \
+  ushort3  _CL_OVERLOADABLE NAME(ushort3 , ushort3 );   \
+  ushort4  _CL_OVERLOADABLE NAME(ushort4 , ushort4 );   \
+  ushort8  _CL_OVERLOADABLE NAME(ushort8 , ushort8 );   \
+  ushort16 _CL_OVERLOADABLE NAME(ushort16, ushort16);   \
+  uint     _CL_OVERLOADABLE NAME(uint    , uint    );   \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint2   );   \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint3   );   \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint4   );   \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   );   \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  );   \
+  __IF_INT64(                                           \
+  ulong    _CL_OVERLOADABLE NAME(ulong   , ulong   );   \
+  ulong2   _CL_OVERLOADABLE NAME(ulong2  , ulong2  );   \
+  ulong3   _CL_OVERLOADABLE NAME(ulong3  , ulong3  );   \
+  ulong4   _CL_OVERLOADABLE NAME(ulong4  , ulong4  );   \
+  ulong8   _CL_OVERLOADABLE NAME(ulong8  , ulong8  );   \
+  ulong16  _CL_OVERLOADABLE NAME(ulong16 , ulong16 );)
+#define _CL_DECLARE_FUNC_LG_GUG(NAME)                   \
+  short    _CL_OVERLOADABLE NAME(char    , uchar   );   \
+  short2   _CL_OVERLOADABLE NAME(char2   , uchar2  );   \
+  short3   _CL_OVERLOADABLE NAME(char3   , uchar3  );   \
+  short4   _CL_OVERLOADABLE NAME(char4   , uchar4  );   \
+  short8   _CL_OVERLOADABLE NAME(char8   , uchar8  );   \
+  short16  _CL_OVERLOADABLE NAME(char16  , uchar16 );   \
+  ushort   _CL_OVERLOADABLE NAME(uchar   , uchar   );   \
+  ushort2  _CL_OVERLOADABLE NAME(uchar2  , uchar2  );   \
+  ushort3  _CL_OVERLOADABLE NAME(uchar3  , uchar3  );   \
+  ushort4  _CL_OVERLOADABLE NAME(uchar4  , uchar4  );   \
+  ushort8  _CL_OVERLOADABLE NAME(uchar8  , uchar8  );   \
+  ushort16 _CL_OVERLOADABLE NAME(uchar16 , uchar16 );   \
+  uint     _CL_OVERLOADABLE NAME(ushort  , ushort  );   \
+  uint2    _CL_OVERLOADABLE NAME(ushort2 , ushort2 );   \
+  uint3    _CL_OVERLOADABLE NAME(ushort3 , ushort3 );   \
+  uint4    _CL_OVERLOADABLE NAME(ushort4 , ushort4 );   \
+  uint8    _CL_OVERLOADABLE NAME(ushort8 , ushort8 );   \
+  uint16   _CL_OVERLOADABLE NAME(ushort16, ushort16);   \
+  int      _CL_OVERLOADABLE NAME(short   , ushort  );   \
+  int2     _CL_OVERLOADABLE NAME(short2  , ushort2 );   \
+  int3     _CL_OVERLOADABLE NAME(short3  , ushort3 );   \
+  int4     _CL_OVERLOADABLE NAME(short4  , ushort4 );   \
+  int8     _CL_OVERLOADABLE NAME(short8  , ushort8 );   \
+  int16    _CL_OVERLOADABLE NAME(short16 , ushort16);   \
+  __IF_INT64(                                           \
+  long     _CL_OVERLOADABLE NAME(int     , uint    );   \
+  long2    _CL_OVERLOADABLE NAME(int2    , uint2   );   \
+  long3    _CL_OVERLOADABLE NAME(int3    , uint3   );   \
+  long4    _CL_OVERLOADABLE NAME(int4    , uint4   );   \
+  long8    _CL_OVERLOADABLE NAME(int8    , uint8   );   \
+  long16   _CL_OVERLOADABLE NAME(int16   , uint16  );   \
+  ulong    _CL_OVERLOADABLE NAME(uint    , uint    );   \
+  ulong2   _CL_OVERLOADABLE NAME(uint2   , uint2   );   \
+  ulong3   _CL_OVERLOADABLE NAME(uint3   , uint3   );   \
+  ulong4   _CL_OVERLOADABLE NAME(uint4   , uint4   );   \
+  ulong8   _CL_OVERLOADABLE NAME(uint8   , uint8   );   \
+  ulong16  _CL_OVERLOADABLE NAME(uint16  , uint16  );)
+#define _CL_DECLARE_FUNC_I_IG(NAME)             \
+  int _CL_OVERLOADABLE NAME(char   );           \
+  int _CL_OVERLOADABLE NAME(char2  );           \
+  int _CL_OVERLOADABLE NAME(char3  );           \
+  int _CL_OVERLOADABLE NAME(char4  );           \
+  int _CL_OVERLOADABLE NAME(char8  );           \
+  int _CL_OVERLOADABLE NAME(char16 );           \
+  int _CL_OVERLOADABLE NAME(short  );           \
+  int _CL_OVERLOADABLE NAME(short2 );           \
+  int _CL_OVERLOADABLE NAME(short3 );           \
+  int _CL_OVERLOADABLE NAME(short4 );           \
+  int _CL_OVERLOADABLE NAME(short8 );           \
+  int _CL_OVERLOADABLE NAME(short16);           \
+  int _CL_OVERLOADABLE NAME(int    );           \
+  int _CL_OVERLOADABLE NAME(int2   );           \
+  int _CL_OVERLOADABLE NAME(int3   );           \
+  int _CL_OVERLOADABLE NAME(int4   );           \
+  int _CL_OVERLOADABLE NAME(int8   );           \
+  int _CL_OVERLOADABLE NAME(int16  );           \
+  __IF_INT64(                                   \
+  int _CL_OVERLOADABLE NAME(long   );           \
+  int _CL_OVERLOADABLE NAME(long2  );           \
+  int _CL_OVERLOADABLE NAME(long3  );           \
+  int _CL_OVERLOADABLE NAME(long4  );           \
+  int _CL_OVERLOADABLE NAME(long8  );           \
+  int _CL_OVERLOADABLE NAME(long16 );)
+#define _CL_DECLARE_FUNC_J_JJ(NAME)                     \
+  int      _CL_OVERLOADABLE NAME(int     , int     );   \
+  int2     _CL_OVERLOADABLE NAME(int2    , int2    );   \
+  int3     _CL_OVERLOADABLE NAME(int3    , int3    );   \
+  int4     _CL_OVERLOADABLE NAME(int4    , int4    );   \
+  int8     _CL_OVERLOADABLE NAME(int8    , int8    );   \
+  int16    _CL_OVERLOADABLE NAME(int16   , int16   );   \
+  uint     _CL_OVERLOADABLE NAME(uint    , uint    );   \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint2   );   \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint3   );   \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint4   );   \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   );   \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  );
+#define _CL_DECLARE_FUNC_J_JJJ(NAME)                            \
+  int      _CL_OVERLOADABLE NAME(int     , int     , int     ); \
+  int2     _CL_OVERLOADABLE NAME(int2    , int2    , int2    ); \
+  int3     _CL_OVERLOADABLE NAME(int3    , int3    , int3    ); \
+  int4     _CL_OVERLOADABLE NAME(int4    , int4    , int4    ); \
+  int8     _CL_OVERLOADABLE NAME(int8    , int8    , int8    ); \
+  int16    _CL_OVERLOADABLE NAME(int16   , int16   , int16   ); \
+  uint     _CL_OVERLOADABLE NAME(uint    , uint    , uint    ); \
+  uint2    _CL_OVERLOADABLE NAME(uint2   , uint2   , uint2   ); \
+  uint3    _CL_OVERLOADABLE NAME(uint3   , uint3   , uint3   ); \
+  uint4    _CL_OVERLOADABLE NAME(uint4   , uint4   , uint4   ); \
+  uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   , uint8   ); \
+  uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  , uint16  );
 
 /* Atomic operations */
 

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -1444,6 +1444,45 @@ void barrier (cl_mem_fence_flags flags);
   uint8    _CL_OVERLOADABLE NAME(uint8   , uint8   , uint8   ); \
   uint16   _CL_OVERLOADABLE NAME(uint16  , uint16  , uint16  );
 
+/* Vector Functions */
+
+#ifdef cl_khr_fp16
+
+#define _CL_DECLARE_VLOAD_HALF(MOD)                                     \
+  float   _CL_OVERLOADABLE vload_half   (size_t offset, const MOD half *p); \
+  float2  _CL_OVERLOADABLE vload_half2  (size_t offset, const MOD half *p); \
+  float3  _CL_OVERLOADABLE vload_half3  (size_t offset, const MOD half *p); \
+  float4  _CL_OVERLOADABLE vload_half4  (size_t offset, const MOD half *p); \
+  float8  _CL_OVERLOADABLE vload_half8  (size_t offset, const MOD half *p); \
+  float16 _CL_OVERLOADABLE vload_half16 (size_t offset, const MOD half *p); \
+  float2  _CL_OVERLOADABLE vloada_half2 (size_t offset, const MOD half *p); \
+  float3  _CL_OVERLOADABLE vloada_half3 (size_t offset, const MOD half *p); \
+  float4  _CL_OVERLOADABLE vloada_half4 (size_t offset, const MOD half *p); \
+  float8  _CL_OVERLOADABLE vloada_half8 (size_t offset, const MOD half *p); \
+  float16 _CL_OVERLOADABLE vloada_half16(size_t offset, const MOD half *p);
+
+/* stores to half may have a suffix: _rte _rtz _rtp _rtn */
+#define _CL_DECLARE_VSTORE_HALF(MOD, SUFFIX)                            \
+  void _CL_OVERLOADABLE vstore_half##SUFFIX   (float   data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstore_half2##SUFFIX  (float2  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstore_half3##SUFFIX  (float3  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstore_half4##SUFFIX  (float4  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstore_half8##SUFFIX  (float8  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstore_half16##SUFFIX (float16 data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstorea_half2##SUFFIX (float2  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstorea_half3##SUFFIX (float3  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstorea_half4##SUFFIX (float4  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstorea_half8##SUFFIX (float8  data, size_t offset, MOD half *p); \
+  void _CL_OVERLOADABLE vstorea_half16##SUFFIX(float16 data, size_t offset, MOD half *p);
+
+#else
+
+// cl_khr_fp16 not defined, define no-op macros
+#define _CL_DECLARE_VLOAD_HALF(MOD)
+#define _CL_DECLARE_VSTORE_HALF(MOD, SUFFIX)
+
+#endif
+
 /* Atomic operations */
 
 #define _CL_DECLARE_ATOMICS(MOD, TYPE)                                  \

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -326,6 +326,16 @@ _CL_STATIC_ASSERT(double16, sizeof(double16) == 16*sizeof(double));
 
 /* Conversion functions */
 
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+//
+// TODO: Only declare these if used
+// This could be an 25% performance improvement!
+//
+// (Just #if 0'ing them all makes test suite complete
+//  in 33s instead of 45s but is obviously incorrect)
+//
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 #define _CL_DECLARE_AS_TYPE(SRC, DST)           \
   DST _CL_OVERLOADABLE as_##DST(SRC a);
 
@@ -1528,6 +1538,8 @@ void barrier (cl_mem_fence_flags flags);
 
 /* Atomic operations */
 
+// TODO: only declare these if used
+
 #define _CL_DECLARE_ATOMICS(MOD, TYPE)                                  \
   _CL_OVERLOADABLE TYPE atomic_add    (volatile MOD TYPE *p, TYPE val); \
   _CL_OVERLOADABLE TYPE atomic_sub    (volatile MOD TYPE *p, TYPE val); \
@@ -1689,58 +1701,37 @@ int printf(const /*constant*/ char * restrict format, ...)
 /* Async Copies from Global to Local Memory, Local to
    Global Memory, and Prefetch */
 
+// TODO: only declare these if used
+
 #ifndef _CL_HAS_EVENT_T
 typedef uint event_t;
 #endif
 
-#define _CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(GENTYPE)            \
-  _CL_OVERLOADABLE                                              \
-  event_t async_work_group_copy (__local GENTYPE *dst,          \
-                                 const __global GENTYPE *src,   \
-                                 size_t num_gentypes,           \
-                                 event_t event);                \
-                                                                \
-  _CL_OVERLOADABLE                                              \
-  event_t async_work_group_copy (__global GENTYPE *dst,         \
-                                 const __local GENTYPE *src,    \
-                                 size_t num_gentypes,           \
-                                 event_t event);                \
-  _CL_OVERLOADABLE                                              \
-  event_t async_work_group_strided_copy (__local GENTYPE *dst,        \
-                                         const __global GENTYPE *src, \
-                                         size_t num_gentypes,         \
-                                         size_t src_stride,           \
-                                         event_t event);              \
-  _CL_OVERLOADABLE                                                    \
-  event_t async_work_group_strided_copy (__global GENTYPE *dst,       \
-                                         const __local GENTYPE *src,  \
-                                         size_t num_gentypes,         \
-                                         size_t dst_stride,           \
-                                         event_t event);              \
-                                                                
+_CL_OVERLOADABLE
+event_t async_work_group_copy (__local void *dst,
+                                const __global void *src,
+                                size_t num_gentypes,
+                                event_t event);
+_CL_OVERLOADABLE
+event_t async_work_group_copy (__global void *dst,
+                                const __local void *src,
+                                size_t num_gentypes,
+                                event_t event);
+_CL_OVERLOADABLE
+event_t async_work_group_strided_copy (__local void *dst,
+                                        const __global void *src,
+                                        size_t num_gentypes,
+                                        size_t src_stride,
+                                        event_t event);
+_CL_OVERLOADABLE
+event_t async_work_group_strided_copy (__global void *dst,
+                                        const __local void *src,
+                                        size_t num_gentypes,
+                                        size_t dst_stride,
+                                        event_t event);
+
 void wait_group_events (int num_events,                      
                         event_t *event_list);                 
-
-#define _CL_DECLARE_ASYNC_COPY_FUNCS(GENTYPE)      \
-  _CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(GENTYPE)     \
-  _CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##2)   \
-  _CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##3)   \
-  _CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##4)   \
-  _CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##8)   \
-  _CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##16)  \
-
-_CL_DECLARE_ASYNC_COPY_FUNCS(char);
-_CL_DECLARE_ASYNC_COPY_FUNCS(uchar);
-_CL_DECLARE_ASYNC_COPY_FUNCS(short);
-_CL_DECLARE_ASYNC_COPY_FUNCS(ushort);
-_CL_DECLARE_ASYNC_COPY_FUNCS(int);
-_CL_DECLARE_ASYNC_COPY_FUNCS(uint);
-__IF_INT64(_CL_DECLARE_ASYNC_COPY_FUNCS(long));
-__IF_INT64(_CL_DECLARE_ASYNC_COPY_FUNCS(ulong));
-
-__IF_FP16(_CL_DECLARE_ASYNC_COPY_FUNCS_SINGLE(half));
-_CL_DECLARE_ASYNC_COPY_FUNCS(float);
-__IF_FP64(_CL_DECLARE_ASYNC_COPY_FUNCS(double));
 
 // Fake prefetch declaration to let it be caught more informatively in WebCLAnalyser
 void prefetch(const __global void *, size_t);

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -1446,6 +1446,49 @@ void barrier (cl_mem_fence_flags flags);
 
 /* Vector Functions */
 
+#define _CL_DECLARE_VLOAD_TYPE_WIDTH(TYPE, WIDTH)                                      \
+  TYPE##WIDTH _CL_OVERLOADABLE vload##WIDTH (size_t offset, const __global   TYPE *p); \
+  TYPE##WIDTH _CL_OVERLOADABLE vload##WIDTH (size_t offset, const __local    TYPE *p); \
+  TYPE##WIDTH _CL_OVERLOADABLE vload##WIDTH (size_t offset, const __constant TYPE *p); \
+  TYPE##WIDTH _CL_OVERLOADABLE vload##WIDTH (size_t offset, const __private  TYPE *p);
+
+#define _CL_DECLARE_VLOAD_WIDTH(WIDTH)                     \
+  _CL_DECLARE_VLOAD_TYPE_WIDTH(char,   WIDTH)              \
+  _CL_DECLARE_VLOAD_TYPE_WIDTH(uchar,  WIDTH)              \
+  _CL_DECLARE_VLOAD_TYPE_WIDTH(short,  WIDTH)              \
+  _CL_DECLARE_VLOAD_TYPE_WIDTH(ushort, WIDTH)              \
+  _CL_DECLARE_VLOAD_TYPE_WIDTH(int,    WIDTH)              \
+  _CL_DECLARE_VLOAD_TYPE_WIDTH(uint,   WIDTH)              \
+  __IF_INT64(                                              \
+              _CL_DECLARE_VLOAD_TYPE_WIDTH(long,  WIDTH)   \
+              _CL_DECLARE_VLOAD_TYPE_WIDTH(ulong, WIDTH)   \
+            )                                              \
+  __IF_FP64(                                               \
+             _CL_DECLARE_VLOAD_TYPE_WIDTH(double, WIDTH)   \
+           )                                               \
+  _CL_DECLARE_VLOAD_TYPE_WIDTH(float, WIDTH)
+
+#define _CL_DECLARE_VSTORE_TYPE_WIDTH(TYPE, WIDTH)                                           \
+  void _CL_OVERLOADABLE vstore##WIDTH (TYPE##WIDTH data, size_t offset, __global  TYPE *p);  \
+  void _CL_OVERLOADABLE vstore##WIDTH (TYPE##WIDTH data, size_t offset, __local   TYPE *p);  \
+  void _CL_OVERLOADABLE vstore##WIDTH (TYPE##WIDTH data, size_t offset, __private TYPE *p);
+
+#define _CL_DECLARE_VSTORE_WIDTH(WIDTH)                     \
+  _CL_DECLARE_VSTORE_TYPE_WIDTH(char,   WIDTH)              \
+  _CL_DECLARE_VSTORE_TYPE_WIDTH(uchar,  WIDTH)              \
+  _CL_DECLARE_VSTORE_TYPE_WIDTH(short,  WIDTH)              \
+  _CL_DECLARE_VSTORE_TYPE_WIDTH(ushort, WIDTH)              \
+  _CL_DECLARE_VSTORE_TYPE_WIDTH(int,    WIDTH)              \
+  _CL_DECLARE_VSTORE_TYPE_WIDTH(uint,   WIDTH)              \
+  __IF_INT64(                                               \
+              _CL_DECLARE_VSTORE_TYPE_WIDTH(long,  WIDTH)   \
+              _CL_DECLARE_VSTORE_TYPE_WIDTH(ulong, WIDTH)   \
+            )                                               \
+  __IF_FP64(                                                \
+             _CL_DECLARE_VSTORE_TYPE_WIDTH(double, WIDTH)   \
+           )                                                \
+  _CL_DECLARE_VSTORE_TYPE_WIDTH(float, WIDTH)
+
 #ifdef cl_khr_fp16
 
 #define _CL_DECLARE_VLOAD_HALF(MOD)                                     \

--- a/test/builtin-vload-indirect.cl
+++ b/test/builtin-vload-indirect.cl
@@ -3,6 +3,9 @@
 // RUN: %webcl-validator %s | %kernel-runner --webcl --kernel builtin_wrappers --global float 7 | grep '^1,2,3,4,0,0,0,0,0'
 // RUN: %webcl-validator %s | %kernel-runner --webcl --kernel builtin_wrappers --global float 8 | grep '^1,2,3,4,5,6,7,8,0'
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 __kernel void builtin_wrappers(__global char *output, 
                                __global float *input)
 {

--- a/test/builtin-vload-prototypes.cl
+++ b/test/builtin-vload-prototypes.cl
@@ -1,6 +1,9 @@
 // Check that the vload functions we declare on demand have the correct parameter lists
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 __kernel void builtin_wrappers(__global char *output, 
                                __global float *input)
 {

--- a/test/builtin-vload-prototypes.cl
+++ b/test/builtin-vload-prototypes.cl
@@ -1,3 +1,4 @@
+// Check that the vload functions we declare on demand have the correct parameter lists
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
 __kernel void builtin_wrappers(__global char *output, 
@@ -5,9 +6,9 @@ __kernel void builtin_wrappers(__global char *output,
 {
     __local int offset;
 
-    // CHECK: error: vload4 argument number 2 must be a pointer
+    // CHECK: error: no matching function for call to 'vload4'
     vload4(input, offset);
 
-    // CHECK: error: Builtin argument check is required.
+    // CHECK: error: no matching function for call to 'vload4'
     vload4(input);
 }

--- a/test/builtin-vload-vstore-variations.cl
+++ b/test/builtin-vload-vstore-variations.cl
@@ -1,13 +1,20 @@
 #ifdef cl_khr_fp64
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 #endif
-// Just check that no calls produce errors in the validator
-// RUN: %webcl-validator %s
+// Check that no calls produce errors in the validator, and there are no implicit decl warnings
+// FIXME: we shouldn't need to -Dcl_khr_fp{16,64} here - they should be defined based on the
+//        corresponding extensions being enabled, as they are in the CLI validator
+// RUN: %webcl-validator %s -Dcl_khr_fp16 -Dcl_khr_fp64 2>&1 | grep -v CHECK | %FileCheck %s
+
+// CHECK-NOT: error:
 
 __kernel void builtin_wrappers(__global char *output, 
                                __global float *f
+#ifdef cl_khr_fp16
+                               , __global half *h
+#endif
 #ifdef cl_khr_fp64
-                               , __global float *d
+                               , __global double *d
 #endif
                                )
 {
@@ -20,70 +27,93 @@ __kernel void builtin_wrappers(__global char *output,
     vload8(offset, f);
     vload16(offset, f);
 
-    vload_half2(offset, f);
-    vload_half4(offset, f);
-    vload_half8(offset, f);
-    vload_half16(offset, f);
+#ifdef cl_khr_fp16
+    // CHECK-NOT: warning: implicit declaration of function 'vload_half2'
+    vload_half2(offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vload_half4'
+    vload_half4(offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vload_half8'
+    vload_half8(offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vload_half16'
+    vload_half16(offset, h);
 
-    vloada_half2(offset, f);
-    vloada_half4(offset, f);
-    vloada_half8(offset, f);
-    vloada_half16(offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vloada_half2'
+    vloada_half2(offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vloada_half4'
+    vloada_half4(offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vloada_half8'
+    vloada_half8(offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vloada_half16'
+    vloada_half16(offset, h);
+#endif // fp16
 
     vstore2((float2)(0, 0), offset, f);
     vstore4((float4)(0, 0, 0, 0), offset, f);
     vstore8((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
     vstore16((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
 
-    vstore_half2((float2)(0, 0), offset, f);
-    vstore_half4((float4)(0, 0, 0, 0), offset, f);
-    vstore_half8((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstore_half16((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+#ifdef cl_khr_fp16
+    // CHECK-NOT: warning: implicit declaration of function 'vstore_half2'
+    vstore_half2((float2)(0, 0), offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vstore_half4'
+    vstore_half4((float4)(0, 0, 0, 0), offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vstore_half8'
+    vstore_half8((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vstore_half16'
+    vstore_half16((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstore_half2_rte((float2)(0, 0), offset, f);
-    vstore_half4_rte((float4)(0, 0, 0, 0), offset, f);
-    vstore_half8_rte((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstore_half16_rte((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    // Catch all the rounding variants, can't be bothered to write them all down
+    // CHECK-NOT: warning: implicit declaration of function 'vstorea?_half1?[2468]_{rte,rtz,rtn,rtp}'
 
-    vstore_half2_rtz((float2)(0, 0), offset, f);
-    vstore_half4_rtz((float4)(0, 0, 0, 0), offset, f);
-    vstore_half8_rtz((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstore_half16_rtz((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    vstore_half2_rte((float2)(0, 0), offset, h);
+    vstore_half4_rte((float4)(0, 0, 0, 0), offset, h);
+    vstore_half8_rte((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstore_half16_rte((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstore_half2_rtn((float2)(0, 0), offset, f);
-    vstore_half4_rtn((float4)(0, 0, 0, 0), offset, f);
-    vstore_half8_rtn((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstore_half16_rtn((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    vstore_half2_rtz((float2)(0, 0), offset, h);
+    vstore_half4_rtz((float4)(0, 0, 0, 0), offset, h);
+    vstore_half8_rtz((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstore_half16_rtz((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstore_half2_rtp((float2)(0, 0), offset, f);
-    vstore_half4_rtp((float4)(0, 0, 0, 0), offset, f);
-    vstore_half8_rtp((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstore_half16_rtp((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    vstore_half2_rtn((float2)(0, 0), offset, h);
+    vstore_half4_rtn((float4)(0, 0, 0, 0), offset, h);
+    vstore_half8_rtn((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstore_half16_rtn((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstorea_half2((float2)(0, 0), offset, f);
-    vstorea_half4((float4)(0, 0, 0, 0), offset, f);
-    vstorea_half8((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstorea_half16((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    vstore_half2_rtp((float2)(0, 0), offset, h);
+    vstore_half4_rtp((float4)(0, 0, 0, 0), offset, h);
+    vstore_half8_rtp((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstore_half16_rtp((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstorea_half2_rte((float2)(0, 0), offset, f);
-    vstorea_half4_rte((float4)(0, 0, 0, 0), offset, f);
-    vstorea_half8_rte((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstorea_half16_rte((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vstorea_half2'
+    vstorea_half2((float2)(0, 0), offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vstorea_half4'
+    vstorea_half4((float4)(0, 0, 0, 0), offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vstorea_half8'
+    vstorea_half8((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    // CHECK-NOT: warning: implicit declaration of function 'vstorea_half16'
+    vstorea_half16((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstorea_half2_rtz((float2)(0, 0), offset, f);
-    vstorea_half4_rtz((float4)(0, 0, 0, 0), offset, f);
-    vstorea_half8_rtz((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstorea_half16_rtz((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    vstorea_half2_rte((float2)(0, 0), offset, h);
+    vstorea_half4_rte((float4)(0, 0, 0, 0), offset, h);
+    vstorea_half8_rte((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstorea_half16_rte((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstorea_half2_rtn((float2)(0, 0), offset, f);
-    vstorea_half4_rtn((float4)(0, 0, 0, 0), offset, f);
-    vstorea_half8_rtn((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstorea_half16_rtn((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    vstorea_half2_rtz((float2)(0, 0), offset, h);
+    vstorea_half4_rtz((float4)(0, 0, 0, 0), offset, h);
+    vstorea_half8_rtz((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstorea_half16_rtz((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
 
-    vstorea_half2_rtp((float2)(0, 0), offset, f);
-    vstorea_half4_rtp((float4)(0, 0, 0, 0), offset, f);
-    vstorea_half8_rtp((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
-    vstorea_half16_rtp((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    vstorea_half2_rtn((float2)(0, 0), offset, h);
+    vstorea_half4_rtn((float4)(0, 0, 0, 0), offset, h);
+    vstorea_half8_rtn((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstorea_half16_rtn((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+
+    vstorea_half2_rtp((float2)(0, 0), offset, h);
+    vstorea_half4_rtp((float4)(0, 0, 0, 0), offset, h);
+    vstorea_half8_rtp((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+    vstorea_half16_rtp((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, h);
+#endif // fp16
 
 #ifdef cl_khr_fp64
     vload2(offset, d);
@@ -91,69 +121,9 @@ __kernel void builtin_wrappers(__global char *output,
     vload8(offset, d);
     vload16(offset, d);
 
-    vload_half2(offset, d);
-    vload_half4(offset, d);
-    vload_half8(offset, d);
-    vload_half16(offset, d);
-
-    vloada_half2(offset, d);
-    vloada_half4(offset, d);
-    vloada_half8(offset, d);
-    vloada_half16(offset, d);
-
     vstore2((double2)(0, 0), offset, d);
     vstore4((double4)(0, 0, 0, 0), offset, d);
     vstore8((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
     vstore16((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstore_half2((double2)(0, 0), offset, d);
-    vstore_half4((double4)(0, 0, 0, 0), offset, d);
-    vstore_half8((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstore_half16((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstore_half2_rte((double2)(0, 0), offset, d);
-    vstore_half4_rte((double4)(0, 0, 0, 0), offset, d);
-    vstore_half8_rte((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstore_half16_rte((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstore_half2_rtz((double2)(0, 0), offset, d);
-    vstore_half4_rtz((double4)(0, 0, 0, 0), offset, d);
-    vstore_half8_rtz((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstore_half16_rtz((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstore_half2_rtn((double2)(0, 0), offset, d);
-    vstore_half4_rtn((double4)(0, 0, 0, 0), offset, d);
-    vstore_half8_rtn((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstore_half16_rtn((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstore_half2_rtp((double2)(0, 0), offset, d);
-    vstore_half4_rtp((double4)(0, 0, 0, 0), offset, d);
-    vstore_half8_rtp((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstore_half16_rtp((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstorea_half2((double2)(0, 0), offset, d);
-    vstorea_half4((double4)(0, 0, 0, 0), offset, d);
-    vstorea_half8((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstorea_half16((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstorea_half2_rte((double2)(0, 0), offset, d);
-    vstorea_half4_rte((double4)(0, 0, 0, 0), offset, d);
-    vstorea_half8_rte((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstorea_half16_rte((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstorea_half2_rtz((double2)(0, 0), offset, d);
-    vstorea_half4_rtz((double4)(0, 0, 0, 0), offset, d);
-    vstorea_half8_rtz((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstorea_half16_rtz((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstorea_half2_rtn((double2)(0, 0), offset, d);
-    vstorea_half4_rtn((double4)(0, 0, 0, 0), offset, d);
-    vstorea_half8_rtn((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstorea_half16_rtn((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-
-    vstorea_half2_rtp((double2)(0, 0), offset, d);
-    vstorea_half4_rtp((double4)(0, 0, 0, 0), offset, d);
-    vstorea_half8_rtp((double8)(0, 0, 0, 0, 0, 0, 0, 0), offset, d);
-    vstorea_half16_rtp((double16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, d);
 #endif
 }

--- a/test/builtin-vload-vstore-variations.cl
+++ b/test/builtin-vload-vstore-variations.cl
@@ -22,9 +22,13 @@ __kernel void builtin_wrappers(__global char *output,
 
     offset = 0;
 
+    // CHECK-NOT: warning: implicit declaration of function 'vload2'
     vload2(offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vload4'
     vload4(offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vload8'
     vload8(offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vload16'
     vload16(offset, f);
 
 #ifdef cl_khr_fp16
@@ -47,9 +51,13 @@ __kernel void builtin_wrappers(__global char *output,
     vloada_half16(offset, h);
 #endif // fp16
 
+    // CHECK-NOT: warning: implicit declaration of function 'vstore2'
     vstore2((float2)(0, 0), offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vstore4'
     vstore4((float4)(0, 0, 0, 0), offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vstore8'
     vstore8((float8)(0, 0, 0, 0, 0, 0, 0, 0), offset, f);
+    // CHECK-NOT: warning: implicit declaration of function 'vstore16'
     vstore16((float16)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), offset, f);
 
 #ifdef cl_khr_fp16
@@ -116,6 +124,9 @@ __kernel void builtin_wrappers(__global char *output,
 #endif // fp16
 
 #ifdef cl_khr_fp64
+    // These are already known to produce no implicit decl warnings, as the float overloads are used above,
+    // but try using them to verify that the double overloads exist (otherwise an error is produced)
+
     vload2(offset, d);
     vload4(offset, d);
     vload8(offset, d);

--- a/test/builtin-vload-wrapper.cl
+++ b/test/builtin-vload-wrapper.cl
@@ -7,6 +7,9 @@
 // RUN: sed 's/@SIZE@/8/g' %s | %webcl-validator - | %kernel-runner --webcl --kernel builtin_wrappers --global float 8 | grep '^1,2,3,4,0,0,0,0,0'
 // RUN: sed 's/@SIZE@/8/g' %s | %webcl-validator - | %kernel-runner --webcl --kernel builtin_wrappers --global float 16 | grep '^1,2,3,4,9,10,11,12'
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 __kernel void builtin_wrappers(__global char *output, 
                                __global float *input)
 {

--- a/test/builtin-vstore-wrapper.cl
+++ b/test/builtin-vstore-wrapper.cl
@@ -7,6 +7,9 @@
 // RUN: sed 's/@SIZE@/8/g' %s | %webcl-validator - | %kernel-runner --webcl --kernel builtin_wrappers --global float 8 | grep '^1,2,3,4,5,6,7,8,0'
 // RUN: sed 's/@SIZE@/8/g' %s | %webcl-validator - | %kernel-runner --webcl --kernel builtin_wrappers --global float 16 | grep '^1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,0'
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 __kernel void builtin_wrappers(__global char *output, 
                                __global float *input)
 {

--- a/test/illegal-image2d-access.cl
+++ b/test/illegal-image2d-access.cl
@@ -1,8 +1,11 @@
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
+const sampler_t sampler =
+    CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
 __kernel void illegal_image_access(
 // CHECK: error: image2d_t parameters can only have read_only or write_only access qualifier
     __read_write image2d_t image)
 {
-    read_imagef(image, (float2) (0.0f, 0.0f));
+    read_imagef(image, sampler, (float2) (0.0f, 0.0f));
 }

--- a/test/read-image.cl
+++ b/test/read-image.cl
@@ -3,10 +3,13 @@
 __kernel void unsafe_builtins(
     image2d_t image)
 {
+    // CHECK-NOT: warning: implicit declaration of function 'read_imagef'
     // CHECK: read_imagef( image,/* transformed */ CLK_ADDRESS_NONE | CLK_FILTER_LINEAR | CLK_NORMALIZED_COORDS_TRUE, (float2)(0, 0));
     read_imagef( image, CLK_FILTER_LINEAR | CLK_ADDRESS_NONE | CLK_NORMALIZED_COORDS_TRUE, (float2)(0, 0));
+    // CHECK-NOT: warning: implicit declaration of function 'read_imagef'
     // CHECK: read_imagef(image,/* transformed */ CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE, (float2)(0, 0));
     read_imagef(image, 3, (float2)(0, 0));
+    // CHECK-NOT: warning: implicit declaration of function 'read_imagei'
     read_imagei(image // f,oo
     // CHECK: /*,bar , * */,/* transformed */ CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE,
                 /*,bar , * */,4/1,

--- a/test/unrecognized-builtins.cl
+++ b/test/unrecognized-builtins.cl
@@ -1,5 +1,5 @@
 // RUN: cat %include/unsafe.h %s | %opencl-validator
-// RUN: %webcl-validator %s -I%include -include unsafe.h 2>&1 | grep -v CHECK | %FileCheck %s
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
 __kernel void unrecognized_builtins(
     __constant int *input,
@@ -7,7 +7,6 @@ __kernel void unrecognized_builtins(
 {
     const size_t i = get_global_id(0);
 
-    // CHECK-NOT: warning: implicit declaration of function 'unsafe_function'
     // CHECK: error: Unsafe builtin not recognized.
     output[i] = unsafe_function(input, i);
 }

--- a/test/unsafe-builtins.cl
+++ b/test/unsafe-builtins.cl
@@ -1,6 +1,9 @@
 // RUN: %opencl-validator < %s
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 __kernel void unsafe_builtins(
     float x,
     __constant float *input,

--- a/test/unsupported-builtins.cl
+++ b/test/unsupported-builtins.cl
@@ -1,5 +1,8 @@
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 __kernel void unsupported_builtins(
     const __global float4 *input,
     int input_stride,

--- a/test/wclv54-mathbuiltin-retvals.cl
+++ b/test/wclv54-mathbuiltin-retvals.cl
@@ -1,0 +1,47 @@
+// RUN: %opencl-validator < %s
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+__kernel void
+LotsOfMathBuiltins(
+    __global uchar4 *result,
+    const float4 mu,
+    const float4 diffuse,
+    const float epsilon)
+{
+    int tx = get_global_id(0);
+    int ty = get_global_id(1);
+    int sx = get_global_size(0);
+    int sy = get_global_size(1);
+    int index = ty * 100 + tx;
+
+    float4 coord = (float4)((float)tx, (float)ty, 0.0f, 0.0f);
+
+    float nx = fast_length(diffuse) - fast_length(coord);
+    float ny = fast_length(mu) - fast_length(coord);
+    float nz = fast_length(diffuse) - fast_length(mu);
+
+    float3 normal = fast_normalize((float3)( nx, ny, nz ));
+
+    float3 light_dir = fast_normalize( normal - normal );
+    float3 eye_dir = fast_normalize( normal - normal );
+    float NdotL = dot( normal, light_dir );
+    float3 reflect_dir = light_dir - 2.0f * NdotL * normal;
+
+    reflect_dir += fabs(normal) * 0.5f;
+// CHECK-NOT: error: can't convert between vector values of different size ('float3' and 'int')
+    float3 diff = reflect_dir * fmax(NdotL, 0.0f);
+    float3 specular = NdotL * half_powr( fmax( dot(eye_dir, reflect_dir), 0.0f), nz );
+
+    float fB = 2.0f * dot( diff, specular );
+    float fB2 = fB * fB;
+    float fC = dot( diffuse, diffuse ) - fB2;
+    float fT = (fB2 - 4.0f * fC);
+    float fD = half_sqrt( fT );
+    float fT0 = ( -fB + fD ) * 0.5f;
+    float fT1 = ( -fB - fD ) * 0.5f;
+    fT = fmin(fT0, fT1);
+
+    float4 color = (float4)(fD, fT0, fT1, fT);
+    uchar4 output = convert_uchar4_sat_rte(color * 255.0f);
+    result[index] = output;
+}

--- a/test/wclv54-mathbuiltin-retvals.cl
+++ b/test/wclv54-mathbuiltin-retvals.cl
@@ -1,6 +1,9 @@
 // RUN: %opencl-validator < %s
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 __kernel void
 LotsOfMathBuiltins(
     __global uchar4 *result,

--- a/test/wclv54-vector-builtin-overloads.cl
+++ b/test/wclv54-vector-builtin-overloads.cl
@@ -1,5 +1,8 @@
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
+// We should be declaring all builtins at the moment
+// CHECK-NOT: warning: implicit declaration of function
+
 kernel void vectorMathBuiltinBug() 
 {
 // CHECK-NOT: error: passing 'float4' to parameter of incompatible type 'double'


### PR DESCRIPTION
This brings back the declarations for OpenCL builtin functions which were originally in kernel.cl, but only if they have been used in the source that is being validated.

This fixes issue #54 and lots of other possible ways to incorrectly parse builtin function calls.

The general approach is to look at the preprocessor identifier table after preprocessing stage is done, and seeing if any lexed identifiers match known OpenCL builtin function names. In this case, the appropriate macro invocations to declare the corresponding function are put into a temporary header that is included by the matcher and validation stages.

This originally increased the time it takes to run the test suite from around 60s to around 70s. For comparison, unconditionally including all builtins makes the test suite take 5-10min. (This is on Visual Studio Debug build, which is very slow to start with)

However, I discovered some interesting optimization possibilities while doing this. One of them is avoiding declaring lots of overloads for those builtin functions whose all overloads are anyway forbidden. This is the case for prefetch() and async_work_group(_strided)_copy(), for which one void \* argument can replace all gentype \* overloads. Nuking the gentype \* overloads brought down time to run the test suite from 70s to ~45s.

It would be possible to optimize further to <=35s by declaring the as_XXX(YYY) functions only if they are used, with the same infrastructure. This would require refactoring the corresponding macros in kernel.cl quite extensively. Smaller optimizations could be achieved by only declaring the atomic_*() functions if used, etc.

Even more optimization suggestions are included as TODO comments.
