### PR TITLE
WebCLAnalyser:handleVarDecl: global scope private variables are now collected

### DIFF
--- a/lib/WebCLVisitor.cpp
+++ b/lib/WebCLVisitor.cpp
@@ -285,6 +285,9 @@ bool WebCLAnalyser::handleVarDecl(clang::VarDecl *decl)
       break;
     case clang::LangAS::opencl_constant:
       info(decl->getLocStart(), "Constant variable declaration. Collect!");
+      if (!decl->getInit()) {
+          error(decl->getLocStart(), "Constant address space variables must be initialized.");
+      }
       collectVariable(decl);
       break;
     case clang::LangAS::opencl_global:
@@ -296,6 +299,8 @@ bool WebCLAnalyser::handleVarDecl(clang::VarDecl *decl)
       if (decl->isFunctionOrMethodVarDecl()) {
         info(decl->getLocStart(), "Private variable declaration. Collect!");
         collectVariable(decl);
+      } else if (decl->hasGlobalStorage()) {
+        error(decl->getLocStart(), "Global scope variables must be in constant address space.");
       } else {
         info(decl->getLocStart(), "Function parameter... skip for now.");
       }

--- a/test/illegal-image2d-access.cl
+++ b/test/illegal-image2d-access.cl
@@ -1,6 +1,6 @@
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
-const sampler_t sampler =
+constant sampler_t sampler =
     CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
 
 __kernel void illegal_image_access(

--- a/test/read-image.cl
+++ b/test/read-image.cl
@@ -4,8 +4,8 @@ __kernel void unsafe_builtins(
     image2d_t image)
 {
     // CHECK-NOT: warning: implicit declaration of function 'read_imagef'
-    // CHECK: read_imagef( image,/* transformed */ CLK_ADDRESS_NONE | CLK_FILTER_LINEAR | CLK_NORMALIZED_COORDS_TRUE, (float2)(0, 0));
-    read_imagef( image, CLK_FILTER_LINEAR | CLK_ADDRESS_NONE | CLK_NORMALIZED_COORDS_TRUE, (float2)(0, 0));
+    // CHECK: read_imagef( image,/* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_LINEAR | CLK_NORMALIZED_COORDS_TRUE, (float2)(0, 0));
+    read_imagef( image, CLK_FILTER_LINEAR | CLK_ADDRESS_MIRRORED_REPEAT | CLK_NORMALIZED_COORDS_TRUE, (float2)(0, 0));
     // CHECK-NOT: warning: implicit declaration of function 'read_imagef'
     // CHECK: read_imagef(image,/* transformed */ CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE, (float2)(0, 0));
     read_imagef(image, 3, (float2)(0, 0));

--- a/test/sampler-type-errors3.cl
+++ b/test/sampler-type-errors3.cl
@@ -1,0 +1,7 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+// CHECK: error: Global scope variables must be in constant address space.
+sampler_t globalsampler1;
+
+// CHECK: error: Constant address space variables must be initialized.
+__constant sampler_t globalsampler2;

--- a/test/sampler-type-transformations.cl
+++ b/test/sampler-type-transformations.cl
@@ -1,5 +1,8 @@
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
+// CHECK: __constant sampler_t global_sampler = /* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE;
+__constant sampler_t global_sampler = 1;
+
 void foo(image2d_t image, sampler_t sampler)
 {
     // this goes through unmodified
@@ -27,8 +30,10 @@ void foo_const(image2d_t image, sampler_t sampler)
 __kernel void unsafe_builtins(image2d_t image,
                               sampler_t sampler)
 {
-    // CHECK: foo(image, sampler);
+    // CHECK: foo(_wcl_allocs, image, sampler);
     foo(image, sampler);
-    // CHECK: foo2(/* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE,/* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE, sampler,/* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE);
+    // CHECK: foo(_wcl_allocs, image, _wcl_constant_allocations.global_sampler);
+    foo(image, global_sampler);
+    // CHECK: foo2(_wcl_allocs, /* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE,/* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE, sampler,/* transformed */ CLK_ADDRESS_MIRRORED_REPEAT | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE);
     foo2(1, 1, sampler, 1);
 }

--- a/test/variable-global-scope.cl
+++ b/test/variable-global-scope.cl
@@ -1,0 +1,10 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+// CHECK: Global scope variables must be in constant address space.
+int global_int;
+
+// CHECK: Constant address space variables must be initialized.
+__constant int global_const_int_fail;
+
+// CHECK-NOT: Constant address space variables must be initialized.
+__constant int global_const_int_ok = 1;


### PR DESCRIPTION
Added also simple test case variable-global-scope.el.
