### PR TITLE
Collect warnings/errors into "validation log", expose through libclv API, print in driver

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -162,12 +162,29 @@ int main(int argc, char const* argv[])
         return EXIT_FAILURE;
     }
 
+    for (cl_int i = 0; i < clvGetProgramLogMessageCount(prog); i++) {
+        // TODO: print line n/o info
+        // TODO: print level
+
+        // Determine message text size
+        size_t textSize = 0;
+        err = clvGetProgramLogMessageText(prog, i, 0, NULL, &textSize);
+        assert(err == CL_SUCCESS);
+
+        // Get and print message text
+        std::string text(textSize, '\0');
+        err = clvGetProgramLogMessageText(prog, i, text.size(), &text[0], &textSize);
+        assert(err == CL_SUCCESS);
+        text.erase(text.size() - 1); // erase NUL
+        std::cerr << text;
+
+        // TODO: print caret
+    }
+
     int exitStatus = EXIT_SUCCESS;
     if (clvGetProgramStatus(prog) == CLV_PROGRAM_ACCEPTED ||
         clvGetProgramStatus(prog) == CLV_PROGRAM_ACCEPTED_WITH_WARNINGS) {
         // Success, print output
-
-        // TODO: print warnings, if any
 
         // Print JSON header
         WebCLHeader header;
@@ -191,8 +208,6 @@ int main(int argc, char const* argv[])
         std::cout << validatedSource;
     } else {
         // Validation failed
-
-        // TODO: print errors
 
         exitStatus = EXIT_FAILURE;
     }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -178,7 +178,17 @@ int main(int argc, char const* argv[])
         text.erase(text.size() - 1); // erase NUL
         std::cerr << text;
 
-        // TODO: print caret
+        // Print relevant source code
+        if (clvProgramLogMessageHasSource(prog, i)) {
+            std::string source(clvGetProgramLogMessageSourceLen(prog, i) + 1, '\0');
+            err = clvGetProgramLogMessageSourceText(
+                prog, i,
+                clvGetProgramLogMessageSourceOffset(prog, i), source.size() - 1,
+                source.size(), &source[0], NULL);
+            assert(err == CL_SUCCESS);
+            source.erase(source.size() - 1); // erase NUL
+            std::cerr << source << '\n';
+        }
     }
 
     int exitStatus = EXIT_SUCCESS;

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char const* argv[])
     }
 
     for (cl_int i = 0; i < clvGetProgramLogMessageCount(prog); i++) {
-        // TODO: print line n/o info
+        // TODO: print line n/o info once we can reasonably map source lines
         // TODO: print level
 
         // Determine message text size

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -162,9 +162,22 @@ int main(int argc, char const* argv[])
         return EXIT_FAILURE;
     }
 
+    // Print validation log
     for (cl_int i = 0; i < clvGetProgramLogMessageCount(prog); i++) {
         // TODO: print line n/o info once we can reasonably map source lines
-        // TODO: print level
+
+        // Print severity
+        switch (clvGetProgramLogMessageLevel(prog, i)) {
+        case CLV_LOG_MESSAGE_NOTE:
+            std::cerr << "note: ";
+            break;
+        case CLV_LOG_MESSAGE_WARNING:
+            std::cerr << "warning: ";
+            break;
+        case CLV_LOG_MESSAGE_ERROR:
+            std::cerr << "error: ";
+            break;
+        }
 
         // Determine message text size
         size_t textSize = 0;
@@ -176,7 +189,7 @@ int main(int argc, char const* argv[])
         err = clvGetProgramLogMessageText(prog, i, text.size(), &text[0], &textSize);
         assert(err == CL_SUCCESS);
         text.erase(text.size() - 1); // erase NUL
-        std::cerr << text;
+        std::cerr << text << '\n';
 
         // Print relevant source code
         if (clvProgramLogMessageHasSource(prog, i)) {

--- a/include/clv/clv.h
+++ b/include/clv/clv.h
@@ -70,6 +70,33 @@ typedef enum {
 CLV_API clv_program_status CLV_CALL clvGetProgramStatus(
     clv_program program);
 
+// Get number of validation log messages (notes, warnings, errors)
+CLV_API cl_int CLV_CALL clvGetProgramLogMessageCount(
+    clv_program program);
+
+// Severity level of a validation log message
+typedef enum {
+    // Informative note
+    CLV_LOG_MESSAGE_NOTE,
+    // Warning
+    CLV_LOG_MESSAGE_WARNING,
+    // Error
+    CLV_LOG_MESSAGE_ERROR
+} clv_program_log_level;
+
+// Get severity level of a validation log message
+CLV_API clv_program_log_level CLV_CALL clvGetProgramLogMessageLevel(
+    clv_program program,
+    cl_uint n);
+
+// Get text of a validation log message
+CLV_API cl_int CLV_CALL clvGetProgramLogMessageText(
+    clv_program program,
+    cl_uint n,
+    size_t buf_size,
+    char *buf,
+    size_t *size_ret);
+
 // Get number of kernels found in program
 CLV_API cl_int CLV_CALL clvGetProgramKernelCount(
     clv_program program);

--- a/include/clv/clv.h
+++ b/include/clv/clv.h
@@ -97,6 +97,31 @@ CLV_API cl_int CLV_CALL clvGetProgramLogMessageText(
     char *buf,
     size_t *size_ret);
 
+// Determine if the given validation log message has associated source code
+CLV_API cl_bool CLV_CALL clvProgramLogMessageHasSource(
+    clv_program program,
+    cl_uint n);
+
+// Get the start offset of the relevant part of the source code
+CLV_API cl_long CLV_CALL clvGetProgramLogMessageSourceOffset(
+    clv_program program,
+    cl_uint n);
+
+// Get the length of relevant part of the source code
+CLV_API size_t CLV_CALL clvGetProgramLogMessageSourceLen(
+    clv_program program,
+    cl_uint n);
+
+// Get (a substring of) the source code associated with the log message
+CLV_API cl_int CLV_CALL clvGetProgramLogMessageSourceText(
+    clv_program program,
+    cl_uint n,
+    cl_long offset, // 0 for full source
+    size_t len, // size_t(-1) for full source
+    size_t buf_size,
+    char *buf,
+    size_t *size_ret);
+
 // Get number of kernels found in program
 CLV_API cl_int CLV_CALL clvGetProgramKernelCount(
     clv_program program);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,6 +26,7 @@ llvm_process_sources(libclv_srcs
   WebCLBuiltins.cpp
   WebCLConfiguration.cpp
   WebCLConsumer.cpp
+  WebCLDiag.cpp
   WebCLHelper.cpp
   WebCLMatcher.cpp
   WebCLPass.cpp

--- a/lib/WebCLDiag.cpp
+++ b/lib/WebCLDiag.cpp
@@ -1,0 +1,85 @@
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#include "WebCLDiag.hpp"
+
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/ADT/SmallString.h"
+
+#include "clang/Frontend/TextDiagnostic.h"
+
+WebCLDiag::WebCLDiag(clang::DiagnosticOptions *opts)
+    : opts(opts), pp(NULL)
+{
+}
+
+WebCLDiag::~WebCLDiag()
+{
+}
+
+void WebCLDiag::BeginSourceFile(const clang::LangOptions &langOpts, const clang::Preprocessor *pp)
+{
+    this->langOpts = langOpts;
+    this->pp = pp;
+}
+
+void WebCLDiag::EndSourceFile()
+{
+    this->pp = NULL;
+}
+
+void WebCLDiag::HandleDiagnostic(clang::DiagnosticsEngine::Level level, const clang::Diagnostic &info)
+{
+    // Updates the warning/error counts, which is what ultimately causes the tools to abort on error
+    DiagnosticConsumer::HandleDiagnostic(level, info);
+
+    /// TODO: don't print, but capture the details for exposing through the API
+    /// vvv is adapted from clang::TextDiagnosticPrinter
+
+    llvm::raw_ostream &OS = llvm::errs();
+
+    // Render the diagnostic message into a temporary buffer eagerly. We'll use
+    // this later as we print out the diagnostic to the terminal.
+    llvm::SmallString<100> OutStr;
+    info.FormatDiagnostic(OutStr);
+
+    // Use a dedicated, simpler path for diagnostics without a valid location.
+    // This is important as if the location is missing, we may be emitting
+    // diagnostics in a context that lacks language options, a source manager, or
+    // other infrastructure necessary when emitting more rich diagnostics.
+    if (!info.getLocation().isValid()) {
+        clang::TextDiagnostic::printDiagnosticLevel(OS, level, opts->ShowColors, opts->CLFallbackMode);
+        clang::TextDiagnostic::printDiagnosticMessage(OS, level, OutStr,
+            /* irrelevant as there is ... */ 0, /* ... no word wrap */ 0, opts->ShowColors);
+        OS.flush();
+        return;
+    }
+
+    clang::TextDiagnostic formatter(OS, langOpts, opts.getPtr());
+
+    formatter.emitDiagnostic(info.getLocation(), level, OutStr,
+        info.getRanges(), llvm::ArrayRef<clang::FixItHint>(),
+        &info.getSourceManager());
+
+    OS.flush();
+}

--- a/lib/WebCLDiag.cpp
+++ b/lib/WebCLDiag.cpp
@@ -23,9 +23,12 @@
 
 #include "WebCLDiag.hpp"
 
+#include <utility>
+
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/ADT/SmallString.h"
 
+#include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/TextDiagnostic.h"
 
 WebCLDiag::WebCLDiag(clang::DiagnosticOptions *opts)
@@ -41,11 +44,53 @@ void WebCLDiag::BeginSourceFile(const clang::LangOptions &langOpts, const clang:
 {
     this->langOpts = langOpts;
     this->pp = pp;
+
+    // There might be a new SourceManager, existing FileIDs are bound to get reused with different source
+    sources.clear();
 }
 
 void WebCLDiag::EndSourceFile()
 {
     this->pp = NULL;
+}
+
+namespace
+{
+    bool collectSourceLocation(
+        const clang::Diagnostic &info,
+        std::map<clang::FileID, std::shared_ptr<std::string> > &sources,
+        WebCLDiag::Message &message)
+    {
+        clang::SourceLocation loc = info.getLocation();
+        if (!loc.isValid())
+            return false;
+
+        clang::SourceManager &sm = info.getSourceManager();
+
+        std::pair<clang::FileID, unsigned> filePosPair = sm.getDecomposedLoc(loc);
+        const clang::FileID &file = filePosPair.first;
+        const unsigned pos = filePosPair.second;
+
+        if (sources.find(file) == sources.end()) {
+            bool invalid = false;
+            llvm::StringRef source = sm.getBufferData(file, &invalid);
+
+            if (invalid)
+                return false;
+
+            sources[file] = std::shared_ptr<std::string>(new std::string(source));
+        }
+
+        message.source = sources[file];
+        message.sourceOffset = pos - sm.getColumnNumber(file, pos) + 1;
+
+        std::string::const_iterator endIter = message.source->begin() + pos;
+        while (endIter != message.source->end() && *endIter != '\r' && *endIter != '\n')
+            ++endIter;
+        message.sourceLen = endIter - message.source->begin() - message.sourceOffset;
+
+        return true;
+    }
 }
 
 void WebCLDiag::HandleDiagnostic(clang::DiagnosticsEngine::Level level, const clang::Diagnostic &info)
@@ -60,9 +105,8 @@ void WebCLDiag::HandleDiagnostic(clang::DiagnosticsEngine::Level level, const cl
     info.FormatDiagnostic(OutStr);
 
     // TODO: omit level from text
-    // TODO: capture source and offsets, omit location and caret from text
 
-    if (info.getLocation().isValid()) {
+    if (collectSourceLocation(info, this->sources, message)) {
         clang::TextDiagnostic formatter(os, langOpts, opts.getPtr());
         formatter.emitDiagnostic(info.getLocation(), level, OutStr,
             info.getRanges(), llvm::ArrayRef<clang::FixItHint>(),

--- a/lib/WebCLDiag.cpp
+++ b/lib/WebCLDiag.cpp
@@ -29,8 +29,8 @@
 
 #include "clang/Basic/SourceManager.h"
 
-WebCLDiag::WebCLDiag(clang::DiagnosticOptions *opts)
-    : opts(opts), pp(NULL)
+WebCLDiag::WebCLDiag()
+    : pp(NULL)
 {
 }
 

--- a/lib/WebCLDiag.cpp
+++ b/lib/WebCLDiag.cpp
@@ -30,7 +30,6 @@
 #include "clang/Basic/SourceManager.h"
 
 WebCLDiag::WebCLDiag()
-    : pp(NULL)
 {
 }
 
@@ -40,16 +39,12 @@ WebCLDiag::~WebCLDiag()
 
 void WebCLDiag::BeginSourceFile(const clang::LangOptions &langOpts, const clang::Preprocessor *pp)
 {
-    this->langOpts = langOpts;
-    this->pp = pp;
-
     // There might be a new SourceManager, existing FileIDs are bound to get reused with different source
     sources.clear();
 }
 
 void WebCLDiag::EndSourceFile()
 {
-    this->pp = NULL;
 }
 
 namespace

--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -22,7 +22,6 @@
 */
 
 #include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/LangOptions.h"
 
 #include <map>
 #include <memory>
@@ -66,7 +65,5 @@ public:
 
 private:
 
-    clang::LangOptions langOpts;
-    const clang::Preprocessor *pp;
     std::map<clang::FileID, std::shared_ptr<std::string> > sources;
 };

--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -24,29 +24,23 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LangOptions.h"
 
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
-#include "llvm/ADT/OwningPtr.h"
-
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace clang {
-    class DiagnosticOptions;
     class FileID;
     class LangOptions;
     class Preprocessor;
-    class TextDiagnostic;
 }
 
 /// Captures Clang warning/error output
-/// Partially based on Clang TextDiagnosticPrinter
 class WebCLDiag : public clang::DiagnosticConsumer
 {
 public:
 
-    WebCLDiag(clang::DiagnosticOptions *opts);
+    WebCLDiag();
     ~WebCLDiag();
 
     void BeginSourceFile(const clang::LangOptions &LO, const clang::Preprocessor *PP);
@@ -72,7 +66,6 @@ public:
 
 private:
 
-    clang::IntrusiveRefCntPtr<clang::DiagnosticOptions> opts;
     clang::LangOptions langOpts;
     const clang::Preprocessor *pp;
     std::map<clang::FileID, std::shared_ptr<std::string> > sources;

--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -1,0 +1,55 @@
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/LangOptions.h"
+
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/OwningPtr.h"
+
+namespace clang {
+    class DiagnosticOptions;
+    class LangOptions;
+    class Preprocessor;
+    class TextDiagnostic;
+}
+
+/// Captures Clang warning/error output
+/// Partially based on Clang TextDiagnosticPrinter
+class WebCLDiag : public clang::DiagnosticConsumer
+{
+public:
+
+    WebCLDiag(clang::DiagnosticOptions *opts);
+    ~WebCLDiag();
+
+    void BeginSourceFile(const clang::LangOptions &LO, const clang::Preprocessor *PP);
+    void EndSourceFile();
+    void HandleDiagnostic(clang::DiagnosticsEngine::Level Level, const clang::Diagnostic &Info);
+
+private:
+
+    clang::IntrusiveRefCntPtr<clang::DiagnosticOptions> opts;
+    clang::LangOptions langOpts;
+    const clang::Preprocessor *pp;
+};

--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -27,6 +27,9 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/OwningPtr.h"
 
+#include <string>
+#include <vector>
+
 namespace clang {
     class DiagnosticOptions;
     class LangOptions;
@@ -46,6 +49,18 @@ public:
     void BeginSourceFile(const clang::LangOptions &LO, const clang::Preprocessor *PP);
     void EndSourceFile();
     void HandleDiagnostic(clang::DiagnosticsEngine::Level Level, const clang::Diagnostic &Info);
+
+    struct Message {
+        clang::DiagnosticsEngine::Level level;
+        std::string text;
+
+        Message(clang::DiagnosticsEngine::Level level)
+            : level(level)
+        {
+        }
+    };
+
+    std::vector<Message> messages;
 
 private:
 

--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -27,11 +27,14 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/OwningPtr.h"
 
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace clang {
     class DiagnosticOptions;
+    class FileID;
     class LangOptions;
     class Preprocessor;
     class TextDiagnostic;
@@ -54,8 +57,13 @@ public:
         clang::DiagnosticsEngine::Level level;
         std::string text;
 
+        std::shared_ptr<std::string> source;
+        std::string::size_type sourceOffset;
+        std::string::size_type sourceLen;
+
         Message(clang::DiagnosticsEngine::Level level)
             : level(level)
+            , source(NULL), sourceOffset(std::string::npos), sourceLen(std::string::npos)
         {
         }
     };
@@ -67,4 +75,5 @@ private:
     clang::IntrusiveRefCntPtr<clang::DiagnosticOptions> opts;
     clang::LangOptions langOpts;
     const clang::Preprocessor *pp;
+    std::map<clang::FileID, std::shared_ptr<std::string> > sources;
 };

--- a/lib/WebCLTool.cpp
+++ b/lib/WebCLTool.cpp
@@ -70,6 +70,11 @@ WebCLTool::~WebCLTool()
     compilations_ = NULL;
 }
 
+void WebCLTool::setDiagnosticConsumer(clang::DiagnosticConsumer *diag)
+{
+    tool_->setDiagnosticConsumer(diag);
+}
+
 void WebCLTool::setExtensions(const std::set<std::string> &extensions)
 {
     extensions_ = extensions;

--- a/lib/WebCLTool.hpp
+++ b/lib/WebCLTool.hpp
@@ -32,6 +32,8 @@
 #include <vector>
 
 namespace clang {
+    class DiagnosticConsumer;
+
     namespace tooling {
         class FixedCompilationDatabase;
     }
@@ -59,6 +61,7 @@ public:
               char const *input, char const *output = NULL);
     virtual ~WebCLTool();
 
+    void setDiagnosticConsumer(clang::DiagnosticConsumer *diag);
     void setExtensions(const std::set<std::string> &extensions);
 
     /// \see clang::tooling::FrontendActionFactory

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -35,10 +35,10 @@
 
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticOptions.h"
-#include "clang/Frontend/TextDiagnosticPrinter.h"
 
-#include "../lib/WebCLArguments.hpp"
-#include "../lib/WebCLVisitor.hpp"
+#include "WebCLArguments.hpp"
+#include "WebCLDiag.hpp"
+#include "WebCLVisitor.hpp"
 
 struct WebCLValidator
 {
@@ -80,7 +80,7 @@ WebCLValidator::WebCLValidator(
     char const* argv[])
     : arguments(inputSource, argc, argv)
     , diagOpts(new clang::DiagnosticOptions())
-    , diag(new clang::TextDiagnosticPrinter(llvm::errs(), diagOpts.getPtr()))
+    , diag(new WebCLDiag(diagOpts.getPtr()))
     , extensions(extensions), exitStatus_(-1)
 {
     diagOpts->ShowFixits = false;

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -32,11 +32,6 @@
 #include <string>
 #include <vector>
 
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
-
-#include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/DiagnosticOptions.h"
-
 #include "WebCLArguments.hpp"
 #include "WebCLDiag.hpp"
 #include "WebCLVisitor.hpp"
@@ -67,7 +62,6 @@ public:
 private:
 
     WebCLArguments arguments;
-    llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagOpts;
     WebCLDiag *diag;
     std::set<std::string> extensions;
 
@@ -85,13 +79,9 @@ WebCLValidator::WebCLValidator(
     int argc,
     char const* argv[])
     : arguments(inputSource, argc, argv)
-    , diagOpts(new clang::DiagnosticOptions())
-    , diag(new WebCLDiag(diagOpts.getPtr()))
+    , diag(new WebCLDiag())
     , extensions(extensions), exitStatus_(-1)
 {
-    diagOpts->ShowLocation = false;
-    diagOpts->ShowCarets = false;
-    diagOpts->ShowFixits = false;
 }
 
 WebCLValidator::~WebCLValidator()

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -34,7 +34,6 @@
 #include "../lib/WebCLArguments.hpp"
 #include "../lib/WebCLVisitor.hpp"
 
-// Proof of concept library API for the library+executable build system
 struct WebCLValidator
 {
 public:

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -89,6 +89,7 @@ WebCLValidator::WebCLValidator(
     , diag(new WebCLDiag(diagOpts.getPtr()))
     , extensions(extensions), exitStatus_(-1)
 {
+    diagOpts->ShowLocation = false;
     diagOpts->ShowCarets = false;
     diagOpts->ShowFixits = false;
 }

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -83,6 +83,7 @@ WebCLValidator::WebCLValidator(
     , diag(new clang::TextDiagnosticPrinter(llvm::errs(), diagOpts.getPtr()))
     , extensions(extensions), exitStatus_(-1)
 {
+    diagOpts->ShowFixits = false;
 }
 
 WebCLValidator::~WebCLValidator()

--- a/test/image2d-type-as-argument2.cl
+++ b/test/image2d-type-as-argument2.cl
@@ -2,7 +2,7 @@
 
 void foo(image2d_t image, int i)
 {
-    // CHECK: warning: implicit declaration of function 'nonexisting' is invalid in C99 [-Wimplicit-function-declaration]
+    // CHECK: warning: implicit declaration of function 'nonexisting'
     // CHECK-NOT: error: image2d_t must always originate from parameters
     nonexisting(image); // 1
 }


### PR DESCRIPTION
Previously, any warnings/errors were emitted directly to stderr by Clang and our WebCLReporter. Now these are collected in a structured form by a new WebCLDiag component and exposed through the API. The CLI validator uses the API to print out the log to stderr in a pretty similar format so existing tests which check for certain errors on invalid source etc continue to work.

Messages are currently quads with:
- severity (enum: note/warning/error)
- text (as formatted by Clang)
- full source code that caused the error (same as input source for preprocessing errors, transformed source otherwise)
- offset/length of the part of the source relevant to the error

This is exposed through the following API:

``` c
// Get number of validation log messages (notes, warnings, errors)
CLV_API cl_int CLV_CALL clvGetProgramLogMessageCount(
    clv_program program);

// Severity level of a validation log message
typedef enum {
    // Informative note
    CLV_LOG_MESSAGE_NOTE,
    // Warning
    CLV_LOG_MESSAGE_WARNING,
    // Error
    CLV_LOG_MESSAGE_ERROR
} clv_program_log_level;

// Get severity level of a validation log message
CLV_API clv_program_log_level CLV_CALL clvGetProgramLogMessageLevel(
    clv_program program,
    cl_uint n);

// Get text of a validation log message
CLV_API cl_int CLV_CALL clvGetProgramLogMessageText(
    clv_program program,
    cl_uint n,
    size_t buf_size,
    char *buf,
    size_t *size_ret);

// Determine if the given validation log message has associated source code
CLV_API cl_bool CLV_CALL clvProgramLogMessageHasSource(
    clv_program program,
    cl_uint n);

// Get the start offset of the relevant part of the source code
CLV_API cl_long CLV_CALL clvGetProgramLogMessageSourceOffset(
    clv_program program,
    cl_uint n);

// Get the length of relevant part of the source code
CLV_API size_t CLV_CALL clvGetProgramLogMessageSourceLen(
    clv_program program,
    cl_uint n);

// Get (a substring of) the source code associated with the log message
CLV_API cl_int CLV_CALL clvGetProgramLogMessageSourceText(
    clv_program program,
    cl_uint n,
    cl_long offset, // 0 for full source
    size_t len, // size_t(-1) for full source
    size_t buf_size,
    char *buf,
    size_t *size_ret);
```

Unfortunately not all code in Clang uses the diagnostics system, so e.g. the error/warning counts are still always emitted to stderr. This would need a fix in clang.

Still missing is the location in the original input source that caused the diagnostic. The line numbers are currently lost in our rewrite/reparsing passes. This could be fixed by using Clang preprocessor #line directives suitably, at which point original source line numbers could be added to the API for better graphical debugging etc.
