### PR TITLE
Use std::tr1::shared_ptr; implement wrapping of remaining pointer-using builtins; use functions instead of macros for clamping

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -140,6 +140,8 @@ int main(int argc, char const* argv[])
     extensions.push_back("cl_khr_fp64");
     extensions.push_back("cl_khr_fp16");
     extensions.push_back("cl_khr_gl_sharing");
+    extensions.push_back("cl_khr_int64_base_atomics");
+    extensions.push_back("cl_khr_int64_extended_atomics");
     extensions.push_back(0);
 
     // Parse user defines

--- a/lib/WebCLBuiltins.cpp
+++ b/lib/WebCLBuiltins.cpp
@@ -35,12 +35,6 @@ static const char *hashReplacements[] = {
 static const int numHashReplacements =
     sizeof(hashReplacements) / sizeof(hashReplacements[0]);
 
-static const char *unsafeMathBuiltins[] = {
-    "fract", "frexp", "lgamma_r", "modf", "remquo", "sincos"
-};
-static const int numUnsafeMathBuiltins =
-    sizeof(unsafeMathBuiltins) / sizeof(unsafeMathBuiltins[0]);
-
 static const char *unsafeVectorBuiltins[] = {
     "vload#", "vload_half", "vload_half#", "vloada_half#",
     "vstore#", "vstore_half", "vstore_half#", "vstorea_#", "vstorea_half#",
@@ -65,7 +59,8 @@ static const char *safeBuiltins[] = {
     "atomic_inc", "atomic_dec",
     "atomic_xchg", "atomic_cmpxchg",
     "atomic_min", "atomic_max",
-    "atomic_and", "atomic_or", "atomic_xor"
+    "atomic_and", "atomic_or", "atomic_xor",
+    "fract", "frexp", "lgamma_r", "modf", "remquo", "sincos"
 };
 static const int numSafeBuiltins =
     sizeof(safeBuiltins) / sizeof(safeBuiltins[0]);
@@ -121,11 +116,13 @@ static struct {
     { "fmin", "_CL_DECLARE_FUNC_V_VS(fmin)\n" },
     { "fmod", "_CL_DECLARE_FUNC_V_VV(fmod)\n" },
     { "fract", "_CL_DECLARE_FUNC_V_VPV(fract)\n" },
+    { "frexp", "_CL_DECLARE_FUNC_V_VPVI(frexp)\n_CL_DECLARE_FUNC_H_HPVI(frexp)\n" },
     { "hypot", "_CL_DECLARE_FUNC_V_VV(hypot)\n" },
     { "ilogb", "_CL_DECLARE_FUNC_K_V(ilogb)\n" },
     { "ldexp", "_CL_DECLARE_FUNC_V_VJ(ldexp)\n" },
     { "ldexp", "_CL_DECLARE_FUNC_V_VI(ldexp)\n" },
     { "lgamma", "_CL_DECLARE_FUNC_V_V(lgamma)\n" },
+    { "lgamma_r", "_CL_DECLARE_FUNC_V_VPVI(lgamma_r)\n_CL_DECLARE_FUNC_H_HPVI(lgamma_r)\n" },
     { "log", "_CL_DECLARE_FUNC_V_V(log)\n" },
     { "log2", "_CL_DECLARE_FUNC_V_V(log2)\n" },
     { "log10", "_CL_DECLARE_FUNC_V_V(log10)\n" },
@@ -188,6 +185,7 @@ static struct {
     { "abs_diff", "_CL_DECLARE_FUNC_UG_GG(abs_diff)\n" },
     { "add_sat", "_CL_DECLARE_FUNC_G_GG(add_sat)\n" },
     { "hadd", "_CL_DECLARE_FUNC_G_GG(hadd)\n" },
+    { "remquo", "_CL_DECLARE_FUNC_V_VVPVI(remquo)\n_CL_DECLARE_FUNC_H_HHPVI(remquo)\n" },
     { "rhadd", "_CL_DECLARE_FUNC_G_GG(rhadd)\n" },
     { "clamp", "_CL_DECLARE_FUNC_G_GGG(clamp)\n" },
     { "clz", "_CL_DECLARE_FUNC_G_G(clz)\n" },
@@ -213,7 +211,9 @@ static struct {
     { "min", "_CL_DECLARE_FUNC_V_VS(min)\n" },
     { "mix", "_CL_DECLARE_FUNC_V_VVV(mix)\n" },
     { "mix", "_CL_DECLARE_FUNC_V_VVS(mix)\n" },
+    { "modf", "_CL_DECLARE_FUNC_V_VPV(modf)\n" },
     { "radians", "_CL_DECLARE_FUNC_V_V(radians)\n" },
+    { "sincos", "_CL_DECLARE_FUNC_V_VPV(sincos)\n" },
     { "step", "_CL_DECLARE_FUNC_V_VV(step)\n" },
     { "step", "_CL_DECLARE_FUNC_V_SV(step)\n" },
     { "smoothstep", "_CL_DECLARE_FUNC_V_VVV(smoothstep)\n" },
@@ -275,14 +275,12 @@ static const int numBuiltinDecls =
     sizeof(builtinDecls) / sizeof(builtinDecls[0]);
 
 WebCLBuiltins::WebCLBuiltins()
-    : unsafeMathBuiltins_()
-    , unsafeVectorBuiltins_()
+    : unsafeVectorBuiltins_()
     , unsupportedBuiltins_()
     , safeBuiltins_()
     , roundingSuffixes_(roundingSuffixes, roundingSuffixes + numRoundingSuffixes)
     , vloadHalfDeclared(false)
 {
-    initialize(unsafeMathBuiltins_, unsafeMathBuiltins, numUnsafeMathBuiltins);
     initialize(unsafeVectorBuiltins_, unsafeVectorBuiltins, numUnsafeVectorBuiltins);
     initialize(unsupportedBuiltins_, unsupportedBuiltins, numUnsupportedBuiltins);
     initialize(safeBuiltins_, safeBuiltins, numSafeBuiltins);
@@ -305,7 +303,6 @@ bool WebCLBuiltins::isSafe(const std::string &builtin) const
 bool WebCLBuiltins::isUnsafe(const std::string &builtin) const
 {
     return
-        unsafeMathBuiltins_.count(builtin) ||
         unsafeVectorBuiltins_.count(builtin);
 }
 

--- a/lib/WebCLBuiltins.cpp
+++ b/lib/WebCLBuiltins.cpp
@@ -52,16 +52,6 @@ static const char *unsafeVectorBuiltins[] = {
 static const int numUnsafeVectorBuiltins =
     sizeof(unsafeVectorBuiltins) / sizeof(unsafeVectorBuiltins[0]);
 
-static const char *unsafeAtomicBuiltins[] = {
-    "atomic_add", "atomic_sub",
-    "atomic_inc", "atomic_dec",
-    "atomic_xchg", "atomic_cmpxchg",
-    "atomic_min", "atomic_max",
-    "atomic_and", "atomic_or", "atomic_xor"
-};
-static const int numUnsafeAtomicBuiltins =
-    sizeof(unsafeAtomicBuiltins) / sizeof(unsafeAtomicBuiltins[0]);
-
 static const char *unsupportedBuiltins[] = {
     "async_work_group_copy", "async_work_group_strided_copy",
     "wait_group_events", "prefetch"
@@ -70,7 +60,12 @@ static const int numUnsupportedBuiltins =
     sizeof(unsupportedBuiltins) / sizeof(unsupportedBuiltins[0]);
 
 static const char *safeBuiltins[] = {
-  "get_image_width", "get_image_height"
+    "get_image_width", "get_image_height",
+    "atomic_add", "atomic_sub",
+    "atomic_inc", "atomic_dec",
+    "atomic_xchg", "atomic_cmpxchg",
+    "atomic_min", "atomic_max",
+    "atomic_and", "atomic_or", "atomic_xor"
 };
 static const int numSafeBuiltins =
     sizeof(safeBuiltins) / sizeof(safeBuiltins[0]);
@@ -282,7 +277,6 @@ static const int numBuiltinDecls =
 WebCLBuiltins::WebCLBuiltins()
     : unsafeMathBuiltins_()
     , unsafeVectorBuiltins_()
-    , unsafeAtomicBuiltins_()
     , unsupportedBuiltins_()
     , safeBuiltins_()
     , roundingSuffixes_(roundingSuffixes, roundingSuffixes + numRoundingSuffixes)
@@ -290,7 +284,6 @@ WebCLBuiltins::WebCLBuiltins()
 {
     initialize(unsafeMathBuiltins_, unsafeMathBuiltins, numUnsafeMathBuiltins);
     initialize(unsafeVectorBuiltins_, unsafeVectorBuiltins, numUnsafeVectorBuiltins);
-    initialize(unsafeAtomicBuiltins_, unsafeAtomicBuiltins, numUnsafeAtomicBuiltins);
     initialize(unsupportedBuiltins_, unsupportedBuiltins, numUnsupportedBuiltins);
     initialize(safeBuiltins_, safeBuiltins, numSafeBuiltins);
 
@@ -313,8 +306,7 @@ bool WebCLBuiltins::isUnsafe(const std::string &builtin) const
 {
     return
         unsafeMathBuiltins_.count(builtin) ||
-        unsafeVectorBuiltins_.count(builtin) ||
-        unsafeAtomicBuiltins_.count(builtin);
+        unsafeVectorBuiltins_.count(builtin);
 }
 
 bool WebCLBuiltins::isUnsupported(const std::string &builtin) const

--- a/lib/WebCLBuiltins.hpp
+++ b/lib/WebCLBuiltins.hpp
@@ -72,8 +72,6 @@ private:
     /// example, 'vload#' is expanded to 'vload2' - 'vload16'.
     void initialize(BuiltinNames &names, const char *patterns[], int numPatterns);
 
-    /// The pointer argument points to a single element.
-    BuiltinNames unsafeMathBuiltins_;
     /// The pointer argument points to an element array.
     BuiltinNames unsafeVectorBuiltins_;
     /// Calling is never allowed.

--- a/lib/WebCLBuiltins.hpp
+++ b/lib/WebCLBuiltins.hpp
@@ -76,8 +76,6 @@ private:
     BuiltinNames unsafeMathBuiltins_;
     /// The pointer argument points to an element array.
     BuiltinNames unsafeVectorBuiltins_;
-    /// The pointer argument points to an (unsigned) integer.
-    BuiltinNames unsafeAtomicBuiltins_;
     /// Calling is never allowed.
     BuiltinNames unsupportedBuiltins_;
     /// Calling is always safe for these, even if they have pointer

--- a/lib/WebCLConfiguration.cpp
+++ b/lib/WebCLConfiguration.cpp
@@ -54,6 +54,7 @@ WebCLConfiguration::WebCLConfiguration()
     : typePrefix_("_Wcl")
     , variablePrefix_("_wcl")
     , macroPrefix_("_WCL")
+    , functionPrefix_("_wcl")
 
     , minSuffix_("min")
     , maxSuffix_("max")
@@ -157,19 +158,44 @@ const std::string WebCLConfiguration::getNameOfAddressSpaceNullPtrRef(unsigned a
     return prefix + privateNullField_;
 }
 
-const std::string WebCLConfiguration::getNameOfLimitClampMacro(
-    unsigned addressSpaceNum, int limitCount) const
+const std::string WebCLConfiguration::getIdentifierForString(std::string str) const
+{
+    std::string result;
+    for (unsigned c = 0; c < str.size(); ++c) {
+        switch (str[c]) {
+        case ' ': {
+            result += "__";
+        } break;
+        case '_': {
+            result += "_u";
+        } break;
+        case 'P': {
+            result += "PP";
+        } break;
+        case '*': {
+            result += "Ptr";
+        } break;
+        default:
+            result += str[c];
+        }
+    }
+    // no additional underscore at the end
+    return result;
+}
+
+const std::string WebCLConfiguration::getNameOfLimitClampFunction(
+    unsigned addressSpaceNum, int limitCount, std::string type) const
 {
     std::stringstream result;
-    result << macroPrefix_ << "_ADDR_CLAMP_" << getNameOfAddressSpace(addressSpaceNum) << "_" << limitCount;
+    result << functionPrefix_ << "_addr_clamp_" << getNameOfAddressSpace(addressSpaceNum) << "_" << limitCount << "_" << getIdentifierForString(type);
     return result.str();
 }
 
-const std::string WebCLConfiguration::getNameOfLimitCheckMacro(
-    unsigned addressSpaceNum, int limitCount) const
+const std::string WebCLConfiguration::getNameOfLimitCheckFunction(
+    unsigned addressSpaceNum, int limitCount, std::string type) const
 {
     std::stringstream result;
-    result << macroPrefix_ << "_ADDR_CHECK_" << getNameOfAddressSpace(addressSpaceNum) << "_" << limitCount;
+    result << functionPrefix_ << "_addr_check_" << getNameOfAddressSpace(addressSpaceNum) << "_" << limitCount << "_" << getIdentifierForString(type);
     return result.str();
 }
 
@@ -304,18 +330,18 @@ const std::string WebCLConfiguration::getIndentation(unsigned int levels) const
     return indentation;
 }
 
-const std::string WebCLConfiguration::getStaticLimitRef(unsigned addressSpaceNum) const
+const std::string WebCLConfiguration::getStaticLimitRef(unsigned addressSpaceNum, std::string cast) const
 {
     std::string prefix = addressSpaceRecordName_ + "->";
 
     switch (addressSpaceNum) {
     case clang::LangAS::opencl_constant:
         prefix += constantLimitsField_ + ".";
-        return prefix + constantMinField_ + ", " + prefix + constantMaxField_;
+        return cast + prefix + constantMinField_ + ", " + cast + prefix + constantMaxField_;
 
     case clang::LangAS::opencl_local:
         prefix += localLimitsField_ + ".";
-        return prefix + localMinField_ + ", " + prefix + localMaxField_;
+        return cast + prefix + localMinField_ + ", " + cast + prefix + localMaxField_;
 
     case clang::LangAS::opencl_global:
         assert(false && "There can't be static allocations in global address space.");
@@ -323,11 +349,11 @@ const std::string WebCLConfiguration::getStaticLimitRef(unsigned addressSpaceNum
 
     default:
         prefix += privatesField_;
-        return "&" + prefix + ", (&" + prefix + " + 1)";
+        return cast + "&" + prefix + ", " + cast + "(&" + prefix + " + 1)";
     }
 }
 
-const std::string WebCLConfiguration::getDynamicLimitRef(const clang::VarDecl *decl) const
+const std::string WebCLConfiguration::getDynamicLimitRef(const clang::VarDecl *decl, std::string cast) const
 {
     std::string prefix = addressSpaceRecordName_ + "->";
 
@@ -349,8 +375,8 @@ const std::string WebCLConfiguration::getDynamicLimitRef(const clang::VarDecl *d
     prefix += ".";
 
     std::stringstream retVal;
-    retVal << prefix << getNameOfLimitField(decl, false) << ", "
-           << prefix << getNameOfLimitField(decl, true);
+    retVal << cast << prefix << getNameOfLimitField(decl, false) << ", "
+           << cast << prefix << getNameOfLimitField(decl, true);
     return retVal.str();
 }
 

--- a/lib/WebCLConfiguration.cpp
+++ b/lib/WebCLConfiguration.cpp
@@ -101,6 +101,10 @@ WebCLConfiguration::WebCLConfiguration()
     , dataWidths_(generateWidths(2, 16) + 3)
     , roundingModes_(StringList() + "rte" + "rtz" + "rtp" + "rtn")
 
+    , atomicOperations1_(StringList() + "atomic_inc" + "atomic_dec")
+    , atomicOperations2_(StringList() + "atomic_add" + "atomic_sub" + "atomic_xchg" + "atomic_min" + "atomic_max" + "atomic_and" + "atomic_or" + "atomic_xor")
+    , atomicOperations3_(StringList() + "atomic_cmpxchg")
+
     , localVariableRenamer_(variablePrefix_ + "_", "_")
     , privateVariableRenamer_(variablePrefix_ + "_", "_")
     , typedefRenamer_("", "")

--- a/lib/WebCLConfiguration.cpp
+++ b/lib/WebCLConfiguration.cpp
@@ -42,7 +42,7 @@ namespace {
     }
 
     template<typename Container, typename T>
-    Container addValue(const Container& list, T value)
+    Container operator+(const Container& list, T value)
     {
 	Container l(list);
 	l.push_back(value);
@@ -98,9 +98,8 @@ WebCLConfiguration::WebCLConfiguration()
 
     , localRangeZeroingMacro_(macroPrefix_ + "_LOCAL_RANGE_INIT")
 
-    , dataWidths_(addValue(generateWidths(2, 16), 3))
-    // this may be a little bit ridiculous but at least we get a constant list initialized
-    , roundingModes_(addValue(addValue(addValue(addValue(StringList(), "rte"), "rtz"), "rtp"), "rtn"))
+    , dataWidths_(generateWidths(2, 16) + 3)
+    , roundingModes_(StringList() + "rte" + "rtz" + "rtp" + "rtn")
 
     , localVariableRenamer_(variablePrefix_ + "_", "_")
     , privateVariableRenamer_(variablePrefix_ + "_", "_")

--- a/lib/WebCLConfiguration.hpp
+++ b/lib/WebCLConfiguration.hpp
@@ -65,14 +65,14 @@ public:
 
     /// \return Name of macro that can be used to validate pointers. The
     /// generated macro with this name returns a valid pointer by making call to
-    /// the macro of name getNameOfLimitCheckMacro.
+    /// the macro of name getNameOfLimitCheckFunction.
     ///
     /// \see getStaticLimitRef
     /// \see getDynamicLimitRef
     /// \see getNullLimitRef
-    /// \see getNameOfLimitCheckMacro
-    const std::string getNameOfLimitClampMacro(
-        unsigned addressSpaceNum, int limitCount) const;
+    /// \see getNameOfLimitCheckFunction
+    const std::string getNameOfLimitClampFunction(
+        unsigned addressSpaceNum, int limitCount, std::string type) const;
     /// \return Name of macro that can be used to validate pointers. The
     /// generated macro with this name returns a boolean indicating whether the
     /// access is permitted or not.
@@ -80,9 +80,9 @@ public:
     /// \see getStaticLimitRef
     /// \see getDynamicLimitRef
     /// \see getNullLimitRef
-    /// \see getNameOfLimitClampMacro
-    const std::string getNameOfLimitCheckMacro(
-        unsigned addressSpaceNum, int limitCount) const;
+    /// \see getNameOfLimitClampFunction
+    const std::string getNameOfLimitCheckFunction(
+        unsigned addressSpaceNum, int limitCount, std::string type) const;
     /// \return Name of macro that describes size of largest memory
     /// reference in given address space.
     const std::string getNameOfSizeMacro(const std::string &asName) const;
@@ -122,17 +122,24 @@ public:
 
     /// \return Minimum and maximum limits of an address space
     /// structure.
-    const std::string getStaticLimitRef(unsigned addressSpaceNum) const;
+    const std::string getStaticLimitRef(unsigned addressSpaceNum, std::string cast = "") const;
     /// \return Minimum and maximum limits of a memory object passed
     /// to a kernel.
-    const std::string getDynamicLimitRef(const clang::VarDecl *decl) const;
+    const std::string getDynamicLimitRef(const clang::VarDecl *decl, std::string cast = "") const;
     /// \return Minimum and maximum limits of a null memory area.
     const std::string getNullLimitRef(unsigned addressSpaceNum) const;
+
+    /// \return Stripped version of str in purpose of using it as an identifier
+    /// Currently only handles spaces and asterisks. The generated sequences
+    /// should be so that the user is not able to generate colliisions
+    /// by choosing identifiers in a certain way.
+    const std::string getIdentifierForString(std::string str) const;
 
     /// Prefixes for generated types, variables and macros.
     const std::string typePrefix_;
     const std::string variablePrefix_;
     const std::string macroPrefix_;
+    const std::string functionPrefix_;
 
     /// Suffixes for memory area lower and upper bounds.
     const std::string minSuffix_;

--- a/lib/WebCLConfiguration.hpp
+++ b/lib/WebCLConfiguration.hpp
@@ -206,6 +206,15 @@ public:
     /// List of rounding modes for vstore_half: rte, rtz, rpt, rtn
     const StringList roundingModes_;
 
+    /// List of single-argument atomic (not atom) operations (inc, dec)
+    const StringList atomicOperations1_;
+
+    /// List of two-argument atomic operations (not atom) (add, sub, xchg, min, max, and, or, xor)
+    const StringList atomicOperations2_;
+
+    /// List of three-argument atomic operations (not atom) (cmpxchg)
+    const StringList atomicOperations3_;
+
 private:
 
     /// Renamer of variables relocated to local address space

--- a/lib/WebCLDiag.cpp
+++ b/lib/WebCLDiag.cpp
@@ -51,7 +51,7 @@ namespace
 {
     bool collectSourceLocation(
         const clang::Diagnostic &info,
-        std::map<clang::FileID, std::shared_ptr<std::string> > &sources,
+        std::map<clang::FileID, std::tr1::shared_ptr<std::string> > &sources,
         WebCLDiag::Message &message)
     {
         clang::SourceLocation loc = info.getLocation();
@@ -71,7 +71,7 @@ namespace
             if (invalid)
                 return false;
 
-            sources[file] = std::shared_ptr<std::string>(new std::string(source));
+            sources[file] = std::tr1::shared_ptr<std::string>(new std::string(source));
         }
 
         message.source = sources[file];

--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -24,7 +24,7 @@
 #include "clang/Basic/Diagnostic.h"
 
 #include <map>
-#include <memory>
+#include <tr1/memory>
 #include <string>
 #include <vector>
 
@@ -50,13 +50,13 @@ public:
         clang::DiagnosticsEngine::Level level;
         std::string text;
 
-        std::shared_ptr<std::string> source;
+        std::tr1::shared_ptr<std::string> source;
         std::string::size_type sourceOffset;
         std::string::size_type sourceLen;
 
         Message(clang::DiagnosticsEngine::Level level)
             : level(level)
-            , source(NULL), sourceOffset(std::string::npos), sourceLen(std::string::npos)
+            , source(), sourceOffset(std::string::npos), sourceLen(std::string::npos)
         {
         }
     };
@@ -65,5 +65,5 @@ public:
 
 private:
 
-    std::map<clang::FileID, std::shared_ptr<std::string> > sources;
+    std::map<clang::FileID, std::tr1::shared_ptr<std::string> > sources;
 };

--- a/lib/WebCLTransformer.cpp
+++ b/lib/WebCLTransformer.cpp
@@ -662,9 +662,24 @@ WebCLTransformer::WebCLTransformer(
     functionWrappers_.push_back(new ReadImage("f"));
     functionWrappers_.push_back(new ReadImage("i"));
 
+    addGenericWrappers(cfg_.atomicOperations1_, 1, 0);
+    addGenericWrappers(cfg_.atomicOperations2_, 2, 0);
+    addGenericWrappers(cfg_.atomicOperations3_, 3, 0);
+
     // note: needs to be inserted after other, more specific, wrappers, as only the first matching handler is
     // executed. In this case this needs to be before ReadImage.
     functionWrappers_.push_back(new SamplerType());
+}
+
+void WebCLTransformer::addGenericWrappers(const StringList& list, 
+    unsigned numArgs,
+    unsigned ptrArgIndex)
+{
+    for (StringList::const_iterator operationIt = list.begin();
+         operationIt != list.end();
+         ++operationIt) {
+        functionWrappers_.push_back(new GenericWrapper(*operationIt, numArgs, ptrArgIndex, ptrArgIndex));
+    }
 }
 
 WebCLTransformer::~WebCLTransformer()

--- a/lib/WebCLTransformer.cpp
+++ b/lib/WebCLTransformer.cpp
@@ -666,6 +666,13 @@ WebCLTransformer::WebCLTransformer(
     addGenericWrappers(cfg_.atomicOperations2_, 2, 0);
     addGenericWrappers(cfg_.atomicOperations3_, 3, 0);
 
+    functionWrappers_.push_back(new GenericWrapper("fract", 2, 1, 0));
+    functionWrappers_.push_back(new GenericWrapper("frexp", 2, 1, 0));
+    functionWrappers_.push_back(new GenericWrapper("modf", 2, 1, 0));
+    functionWrappers_.push_back(new GenericWrapper("lgamma_r", 2, 1, 0));
+    functionWrappers_.push_back(new GenericWrapper("remquo", 3, 2, 0));
+    functionWrappers_.push_back(new GenericWrapper("sincos", 2, 1, 0));
+
     // note: needs to be inserted after other, more specific, wrappers, as only the first matching handler is
     // executed. In this case this needs to be before ReadImage.
     functionWrappers_.push_back(new SamplerType());

--- a/lib/WebCLTransformer.hpp
+++ b/lib/WebCLTransformer.hpp
@@ -354,6 +354,11 @@ private:
     /// \brief Inserts kernel prologue to start of kernel body.
     bool rewriteKernelPrologue(const clang::FunctionDecl *kernel);
 
+    /// Adds generic wrappers from a sequence; reduces code duplication
+    void addGenericWrappers(const StringList& list,
+        unsigned numArgs,
+        unsigned ptrArgIndex);
+
     /// Writes a variable declaration to a stream in the form it
     /// should be declared inside an address space structure.
     ///

--- a/lib/WebCLTransformer.hpp
+++ b/lib/WebCLTransformer.hpp
@@ -33,6 +33,7 @@
 #include <set>
 #include <utility>
 #include <sstream>
+#include <tr1/tuple>
 
 namespace clang {
     class ArraySubscriptExpr;
@@ -278,15 +279,15 @@ public:
     /// Used for implementing function wrappers
     class FunctionCallWrapper;
 
-    enum MacroKind {
-	MACRO_CLAMP,
-	MACRO_CHECK
+    enum CheckKind {
+	CHECK_CLAMP,
+	CHECK_CHECK
     };
     /// \return A macro call that forces the given address to point to
     /// a safe memory area.
     ///
     /// e.g. _WCL_ADDR_global_1(__global int *, addr, _wcl_allocs->gl.array_min, _wcl_allocs->gl.array_max, _wcl_allocs->gn)
-    std::string getCheckMacroCall(MacroKind kind, std::string addr, std::string type, unsigned size, AddressSpaceLimits &limits);
+    std::string getCheckFunctionCall(CheckKind kind, std::string addr, std::string type, unsigned size, AddressSpaceLimits &limits);
 
 private:
 
@@ -296,9 +297,9 @@ private:
     /// Set of all different clamp macro call types in the program. One
     /// pair for each address space and limit count:
     /// <address space number, limit count>.
-    typedef std::pair< unsigned, unsigned > ClampMacroKey;
-    typedef std::set<ClampMacroKey> RequiredMacroSet;
-    RequiredMacroSet usedClampMacros_;
+    typedef std::tr1::tuple< unsigned, unsigned, std::string > ClampFunctionKey;
+    typedef std::set<ClampFunctionKey> RequiredFunctionSet;
+    RequiredFunctionSet usedClampFunctions_;
 
     /// Stream for inserting code at the beginning of each kernel or
     /// helper function.
@@ -319,8 +320,8 @@ private:
     /// Stream for code at the start of the module like typedefs and
     /// address space structures.
     std::stringstream modulePrologue_;
-    /// Stream for code after limit macros, eg. for builtin macros
-    std::stringstream afterLimitMacros_;
+    /// Stream for code after limit functions, eg. for builtin functions/macros
+    std::stringstream afterLimitFunctions_;
   
     /// Set to ensure that we aren't initializing relocated parameters
     /// multiple times.
@@ -377,16 +378,16 @@ private:
                              const std::string &name);
 
     /// \return A full expression (incorporating a macro call from
-    /// getClampMacroCall) call that forces the given address to point to a safe
+    /// getClampFunctionCall) call that forces the given address to point to a safe
     /// memory area.
-    std::string getClampMacroExpression(clang::Expr *access, unsigned size, AddressSpaceLimits &limits);
+    std::string getClampFunctionExpression(clang::Expr *access, unsigned size, AddressSpaceLimits &limits);
 
     /// \brief Writes bytestream generated from general.cl to stream.
     void emitGeneralCode(std::ostream &out);
   
-    /// \brief Goes through the set of all generated _WCL_ADDR_* calls
-    /// and writes corresponding _WCL_ADDR_* #defines to the stream.
-    void emitLimitMacros(std::ostream &out);
+    /// \brief Goes through the set of all generated _wcl_addr_* calls
+    /// and writes corresponding _wcl_addr_* functions to the stream.
+    void emitLimitFunctions(std::ostream &out);
   
     /// \return Macro definitions for checking and clamping addresses in given
     /// address space with given limit count.
@@ -395,7 +396,7 @@ private:
     /// #define _WCL_ADDR_CHECK_local_2(type, addr, min1, max1, min2, max2) (<macro code>)
     /// #define _WCL_ADDR_CLAMP_local_2(type, addr, min1, max1, min2, max2, asnull) (<macro code>)
     /// the clamping macro is defined in terms of the checking macro
-    std::string getWclAddrCheckMacroDefinition(unsigned addrSpaceNum, unsigned limitCount);
+    std::string getWclAddrCheckFunctionDefinition(ClampFunctionKey clamp);
 
     /// Write generated code at the beginning of module.
     void emitPrologue(std::ostream &out);

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -1530,7 +1530,16 @@ void barrier (cl_mem_fence_flags flags);
 
 // TODO: only declare these if used
 
-#define _CL_DECLARE_ATOMICS(MOD, TYPE)                                  \
+// special versions that allow to differentiate between cl_khr_fp16 and  cl_khr_fp64
+#define _CL_DECLARE_ATOMICS_BASIC(MOD, TYPE)    \
+  _CL_OVERLOADABLE TYPE atomic_add    (volatile MOD TYPE *p, TYPE val); \
+  _CL_OVERLOADABLE TYPE atomic_sub    (volatile MOD TYPE *p, TYPE val); \
+  _CL_OVERLOADABLE TYPE atomic_xchg   (volatile MOD TYPE *p, TYPE val); \
+  _CL_OVERLOADABLE TYPE atomic_inc    (volatile MOD TYPE *p);           \
+  _CL_OVERLOADABLE TYPE atomic_dec    (volatile MOD TYPE *p);           \
+  _CL_OVERLOADABLE TYPE atomic_cmpxchg(volatile MOD TYPE *p, TYPE cmp, TYPE val);
+  
+#define _CL_DECLARE_ATOMICS_EXTENDED(MOD, TYPE)                                  \
   _CL_OVERLOADABLE TYPE atomic_add    (volatile MOD TYPE *p, TYPE val); \
   _CL_OVERLOADABLE TYPE atomic_sub    (volatile MOD TYPE *p, TYPE val); \
   _CL_OVERLOADABLE TYPE atomic_xchg   (volatile MOD TYPE *p, TYPE val); \
@@ -1542,6 +1551,11 @@ void barrier (cl_mem_fence_flags flags);
   _CL_OVERLOADABLE TYPE atomic_and    (volatile MOD TYPE *p, TYPE val); \
   _CL_OVERLOADABLE TYPE atomic_or     (volatile MOD TYPE *p, TYPE val); \
   _CL_OVERLOADABLE TYPE atomic_xor    (volatile MOD TYPE *p, TYPE val);
+
+#define _CL_DECLARE_ATOMICS(MOD, TYPE)                                  \
+  _CL_DECLARE_ATOMICS_BASIC(MOD, TYPE)                                  \
+  _CL_DECLARE_ATOMICS_EXTENDED(MOD, TYPE)
+
 _CL_DECLARE_ATOMICS(__global, int )
 _CL_DECLARE_ATOMICS(__global, uint)
 _CL_DECLARE_ATOMICS(__local , int )
@@ -1549,6 +1563,20 @@ _CL_DECLARE_ATOMICS(__local , uint)
 
 _CL_OVERLOADABLE float atomic_xchg(volatile __global float *p, float val);
 _CL_OVERLOADABLE float atomic_xchg(volatile __local  float *p, float val);
+
+// TODO: wrap behind #ifdef cl_khr_int64_base_atomics
+#  pragma OPENCL EXTENSION cl_khr_int64_base_atomics: enable
+_CL_DECLARE_ATOMICS_BASIC(__global, long )
+_CL_DECLARE_ATOMICS_BASIC(__global, ulong)
+_CL_DECLARE_ATOMICS_BASIC(__local , long )
+_CL_DECLARE_ATOMICS_BASIC(__local , ulong)
+
+// TODO: wrap behind #ifdef cl_khr_int64_extended_atomics
+#  pragma OPENCL EXTENSION cl_khr_int64_extended_atomics: enable
+_CL_DECLARE_ATOMICS_EXTENDED(__global, long )
+_CL_DECLARE_ATOMICS_EXTENDED(__global, ulong)
+_CL_DECLARE_ATOMICS_EXTENDED(__local , long )
+_CL_DECLARE_ATOMICS_EXTENDED(__local , ulong)
 
 #define atom_add     atomic_add
 #define atom_sub     atomic_sub

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -669,6 +669,46 @@ void barrier (cl_mem_fence_flags flags);
   double4  _CL_OVERLOADABLE NAME(double4 , double4 , double4 );         \
   double8  _CL_OVERLOADABLE NAME(double8 , double8 , double8 );         \
   double16 _CL_OVERLOADABLE NAME(double16, double16, double16);)
+#define _CL_DECLARE_FUNC_V_VVPVI(NAME)                                  \
+  float    _CL_OVERLOADABLE NAME(float   , float   , __local int *);    \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  , __local int2 *);   \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  , __local int3 *);   \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  , __local int4 *);   \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  , __local int8 *);   \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 , __local int16 *);  \
+  __IF_FP64(                                                             \
+  double   _CL_OVERLOADABLE NAME(double  , double  , __local int *);    \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 , __local int2 *);   \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 , __local int3 *);   \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 , __local int4 *);   \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 , __local int8 *);   \
+  double16 _CL_OVERLOADABLE NAME(double16, double16, __local int16 *);) \
+  float    _CL_OVERLOADABLE NAME(float   , float   , __private int *);    \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  , __private int2 *);   \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  , __private int3 *);   \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  , __private int4 *);   \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  , __private int8 *);   \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 , __private int16 *);  \
+  __IF_FP64(                                                             \
+  double   _CL_OVERLOADABLE NAME(double  , double  , __private int *);    \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 , __private int2 *);   \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 , __private int3 *);   \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 , __private int4 *);   \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 , __private int8 *);   \
+  double16 _CL_OVERLOADABLE NAME(double16, double16, __private int16 *);) \
+  float    _CL_OVERLOADABLE NAME(float   , float   , __global int *);    \
+  float2   _CL_OVERLOADABLE NAME(float2  , float2  , __global int2 *);   \
+  float3   _CL_OVERLOADABLE NAME(float3  , float3  , __global int3 *);   \
+  float4   _CL_OVERLOADABLE NAME(float4  , float4  , __global int4 *);   \
+  float8   _CL_OVERLOADABLE NAME(float8  , float8  , __global int8 *);   \
+  float16  _CL_OVERLOADABLE NAME(float16 , float16 , __global int16 *);  \
+  __IF_FP64(                                                             \
+  double   _CL_OVERLOADABLE NAME(double  , double  , __global int *);    \
+  double2  _CL_OVERLOADABLE NAME(double2 , double2 , __global int2 *);   \
+  double3  _CL_OVERLOADABLE NAME(double3 , double3 , __global int3 *);   \
+  double4  _CL_OVERLOADABLE NAME(double4 , double4 , __global int4 *);   \
+  double8  _CL_OVERLOADABLE NAME(double8 , double8 , __global int8 *);   \
+  double16 _CL_OVERLOADABLE NAME(double16, double16, __global int16 *);)
 #define _CL_DECLARE_FUNC_V_VVS(NAME)                            \
   float2   _CL_OVERLOADABLE NAME(float2  , float2  , float );   \
   float3   _CL_OVERLOADABLE NAME(float3  , float3  , float );   \
@@ -853,6 +893,66 @@ void barrier (cl_mem_fence_flags flags);
   double4  _CL_OVERLOADABLE NAME(double4 , __private double4 *);        \
   double8  _CL_OVERLOADABLE NAME(double8 , __private double8 *);        \
   double16 _CL_OVERLOADABLE NAME(double16, __private double16*);)
+#define _CL_DECLARE_FUNC_V_VPVI(NAME)                                   \
+  float    _CL_OVERLOADABLE NAME(float   , __global  int   *);          \
+  float2   _CL_OVERLOADABLE NAME(float2  , __global  int2  *);          \
+  float3   _CL_OVERLOADABLE NAME(float3  , __global  int3  *);          \
+  float4   _CL_OVERLOADABLE NAME(float4  , __global  int4  *);          \
+  float8   _CL_OVERLOADABLE NAME(float8  , __global  int8  *);          \
+  float16  _CL_OVERLOADABLE NAME(float16 , __global  int16 *);          \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , __global  int  *);           \
+  double2  _CL_OVERLOADABLE NAME(double2 , __global  int2 *);           \
+  double3  _CL_OVERLOADABLE NAME(double3 , __global  int3 *);           \
+  double4  _CL_OVERLOADABLE NAME(double4 , __global  int4 *);           \
+  double8  _CL_OVERLOADABLE NAME(double8 , __global  int8 *);           \
+  double16 _CL_OVERLOADABLE NAME(double16, __global  int16*);)          \
+  float    _CL_OVERLOADABLE NAME(float   , __local   int *);            \
+  float2   _CL_OVERLOADABLE NAME(float2  , __local   int2 *);           \
+  float3   _CL_OVERLOADABLE NAME(float3  , __local   int3 *);           \
+  float4   _CL_OVERLOADABLE NAME(float4  , __local   int4 *);           \
+  float8   _CL_OVERLOADABLE NAME(float8  , __local   int8 *);           \
+  float16  _CL_OVERLOADABLE NAME(float16 , __local   int16 *);          \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , __local   int *);            \
+  double2  _CL_OVERLOADABLE NAME(double2 , __local   int2 *);           \
+  double3  _CL_OVERLOADABLE NAME(double3 , __local   int3 *);           \
+  double4  _CL_OVERLOADABLE NAME(double4 , __local   int4 *);           \
+  double8  _CL_OVERLOADABLE NAME(double8 , __local   int8 *);           \
+  double16 _CL_OVERLOADABLE NAME(double16, __local   int16 *);)         \
+  float    _CL_OVERLOADABLE NAME(float   , __private int *);            \
+  float2   _CL_OVERLOADABLE NAME(float2  , __private int2 *);           \
+  float3   _CL_OVERLOADABLE NAME(float3  , __private int3 *);           \
+  float4   _CL_OVERLOADABLE NAME(float4  , __private int4 *);           \
+  float8   _CL_OVERLOADABLE NAME(float8  , __private int8 *);           \
+  float16  _CL_OVERLOADABLE NAME(float16 , __private int16 *);          \
+  __IF_FP64(                                                            \
+  double   _CL_OVERLOADABLE NAME(double  , __private int *);            \
+  double2  _CL_OVERLOADABLE NAME(double2 , __private int2 *);           \
+  double3  _CL_OVERLOADABLE NAME(double3 , __private int3 *);           \
+  double4  _CL_OVERLOADABLE NAME(double4 , __private int4 *);           \
+  double8  _CL_OVERLOADABLE NAME(double8 , __private int8 *);           \
+  double16 _CL_OVERLOADABLE NAME(double16, __private int16 *);)
+#define _CL_DECLARE_FUNC_H_HPVI(NAME)                               \
+  __IF_FP16(                                                        \
+  half    _CL_OVERLOADABLE NAME(half   , __global  int   *);        \
+  half2   _CL_OVERLOADABLE NAME(half2  , __global  int2  *);        \
+  half3   _CL_OVERLOADABLE NAME(half3  , __global  int3  *);        \
+  half4   _CL_OVERLOADABLE NAME(half4  , __global  int4  *);        \
+  half8   _CL_OVERLOADABLE NAME(half8  , __global  int8  *);        \
+  half16  _CL_OVERLOADABLE NAME(half16 , __global  int16 *);        \
+  half    _CL_OVERLOADABLE NAME(half   , __local   int   *);        \
+  half2   _CL_OVERLOADABLE NAME(half2  , __local   int2  *);        \
+  half3   _CL_OVERLOADABLE NAME(half3  , __local   int3  *);        \
+  half4   _CL_OVERLOADABLE NAME(half4  , __local   int4  *);        \
+  half8   _CL_OVERLOADABLE NAME(half8  , __local   int8  *);        \
+  half16  _CL_OVERLOADABLE NAME(half16 , __local   int16 *);        \
+  half    _CL_OVERLOADABLE NAME(half   , __private int   *);        \
+  half2   _CL_OVERLOADABLE NAME(half2  , __private int2  *);        \
+  half3   _CL_OVERLOADABLE NAME(half3  , __private int3  *);        \
+  half4   _CL_OVERLOADABLE NAME(half4  , __private int4  *);        \
+  half8   _CL_OVERLOADABLE NAME(half8  , __private int8  *);        \
+  half16  _CL_OVERLOADABLE NAME(half16 , __private int16 *);)
 #define _CL_DECLARE_FUNC_V_SV(NAME)                     \
   float2   _CL_OVERLOADABLE NAME(float , float2  );     \
   float3   _CL_OVERLOADABLE NAME(float , float3  );     \
@@ -907,6 +1007,26 @@ void barrier (cl_mem_fence_flags flags);
   double _CL_OVERLOADABLE NAME(double4 );       \
   double _CL_OVERLOADABLE NAME(double8 );       \
   double _CL_OVERLOADABLE NAME(double16);)
+#define _CL_DECLARE_FUNC_H_HHPVI(NAME)                             \
+  __IF_FP16(                                                       \
+  half _CL_OVERLOADABLE NAME(half, half, __local int *);           \
+  half _CL_OVERLOADABLE NAME(half, half, __private int *);         \
+  half _CL_OVERLOADABLE NAME(half, half, __global int *);          \
+  half2 _CL_OVERLOADABLE NAME(half2, half2, __local int2 *);       \
+  half2 _CL_OVERLOADABLE NAME(half2, half2, __private int2 *);     \
+  half2 _CL_OVERLOADABLE NAME(half2, half2, __global int2 *);      \
+  half3 _CL_OVERLOADABLE NAME(half3, half3, __local int3 *);       \
+  half3 _CL_OVERLOADABLE NAME(half3, half3, __private int3 *);     \
+  half3 _CL_OVERLOADABLE NAME(half3, half3, __global int3 *);      \
+  half4 _CL_OVERLOADABLE NAME(half4, half4, __local int4 *);       \
+  half4 _CL_OVERLOADABLE NAME(half4, half4, __private int4 *);     \
+  half4 _CL_OVERLOADABLE NAME(half4, half4, __global int4 *);      \
+  half8 _CL_OVERLOADABLE NAME(half8, half8, __local int8 *);       \
+  half8 _CL_OVERLOADABLE NAME(half8, half8, __private int8 *);     \
+  half8 _CL_OVERLOADABLE NAME(half8, half8, __global int8 *);      \
+  half16 _CL_OVERLOADABLE NAME(half16, half16, __local int16 *);   \
+  half16 _CL_OVERLOADABLE NAME(half16, half16, __private int16 *); \
+  half16 _CL_OVERLOADABLE NAME(half16, half16, __global int16 *);)
 #define _CL_DECLARE_FUNC_S_VV(NAME)                     \
   float  _CL_OVERLOADABLE NAME(float   , float   );     \
   float  _CL_OVERLOADABLE NAME(float2  , float2  );     \

--- a/test/access-array.cl
+++ b/test/access-array.cl
@@ -11,15 +11,15 @@ int get_indexed_value(
     __global int *array, int index)
 {
     const int triple[3] = { 0, 1, 2 };
-    // CHECK: const int sum1 = (*(_WCL_ADDR_CLAMP_global_1(__global int *, (array)+(index), 1, _wcl_allocs->gl.access_array__array_min, _wcl_allocs->gl.access_array__array_max, _wcl_allocs->gn))) + (*(_WCL_ADDR_CLAMP_global_1(__global int *, (array)+(0), 1, _wcl_allocs->gl.access_array__array_min, _wcl_allocs->gl.access_array__array_max, _wcl_allocs->gn))) + (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(index), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))
+    // CHECK: const int sum1 = (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((array)+(index), 1, (__global int *)_wcl_allocs->gl.access_array__array_min, (__global int *)_wcl_allocs->gl.access_array__array_max, (__global int *)_wcl_allocs->gn))) + (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((array)+(0), 1, (__global int *)_wcl_allocs->gl.access_array__array_min, (__global int *)_wcl_allocs->gl.access_array__array_max, (__global int *)_wcl_allocs->gn))) + (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(index), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn)));
     const int sum1 = array[index] + array[0] + triple[index];
-    // CHECK: const int sum2 = (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(0), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn))) + (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(1), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn))) + (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(2), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))
+    // CHECK: const int sum2 = (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(0), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn))) + (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(1), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn))) + (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(2), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn)));
     const int sum2 = triple[0] + triple[1] + triple[2];
-    // CHECK: const int sum3 = (*(_WCL_ADDR_CLAMP_global_1(__global int *, (array)+(index), 1, _wcl_allocs->gl.access_array__array_min, _wcl_allocs->gl.access_array__array_max, _wcl_allocs->gn))) + (*(_WCL_ADDR_CLAMP_global_1(__global int *, (array)+(0), 1, _wcl_allocs->gl.access_array__array_min, _wcl_allocs->gl.access_array__array_max, _wcl_allocs->gn))) + (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(index), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))
+    // CHECK: const int sum3 = (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((array)+(index), 1, (__global int *)_wcl_allocs->gl.access_array__array_min, (__global int *)_wcl_allocs->gl.access_array__array_max, (__global int *)_wcl_allocs->gn))) + (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((array)+(0), 1, (__global int *)_wcl_allocs->gl.access_array__array_min, (__global int *)_wcl_allocs->gl.access_array__array_max, (__global int *)_wcl_allocs->gn))) + (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(index), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn)));
 #ifndef __PLATFORM_AMD__
     const int sum3 = index[array] + 0[array] + index[triple];
 #endif
-    // CHECK: const int sum4 = (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(0), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn))) + (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(1), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn))) + (*(_WCL_ADDR_CLAMP_private_1(const int *, (_wcl_allocs->pa._wcl_triple)+(2), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))
+    // CHECK: const int sum4 = (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(0), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn))) + (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(1), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn))) + (*(_wcl_addr_clamp_private_1_const__int__Ptr((_wcl_allocs->pa._wcl_triple)+(2), 1, (const int *)&_wcl_allocs->pa, (const int *)(&_wcl_allocs->pa + 1), (const int *)_wcl_allocs->pn)));
 #ifndef __PLATFORM_AMD__
     const int sum4 = 0[triple] + 1[triple] + 2[triple];
 #endif
@@ -34,9 +34,9 @@ void set_indexed_value(
     // CHECK: _WclProgramAllocations *_wcl_allocs,
     __global int *array, int index, int value)
 {
-    // CHECK: (*(_WCL_ADDR_CLAMP_global_1(__global int *, (array)+(index), 1, _wcl_allocs->gl.access_array__array_min, _wcl_allocs->gl.access_array__array_max, _wcl_allocs->gn))) += value;
+    // CHECK: (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((array)+(index), 1, (__global int *)_wcl_allocs->gl.access_array__array_min, (__global int *)_wcl_allocs->gl.access_array__array_max, (__global int *)_wcl_allocs->gn))) += value;
     array[index] += value;
-    // CHECK: (*(_WCL_ADDR_CLAMP_global_1(__global int *, (array)+(index), 1, _wcl_allocs->gl.access_array__array_min, _wcl_allocs->gl.access_array__array_max, _wcl_allocs->gn))) += value;
+    // CHECK: (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((array)+(index), 1, (__global int *)_wcl_allocs->gl.access_array__array_min, (__global int *)_wcl_allocs->gl.access_array__array_max, (__global int *)_wcl_allocs->gn))) += value;
 #ifndef __PLATFORM_AMD__
     index[array] += value;
 #endif

--- a/test/access-pointer.cl
+++ b/test/access-pointer.cl
@@ -10,7 +10,7 @@ int get_pointed_value(
     // CHECK: _WclProgramAllocations *_wcl_allocs,
     __global int *pointer)
 {
-    // CHECK: return (*(_WCL_ADDR_CLAMP_global_1(__global int *, (pointer), 1, _wcl_allocs->gl.access_pointer__array_min, _wcl_allocs->gl.access_pointer__array_max, _wcl_allocs->gn)));
+    // CHECK: return (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((pointer), 1, (__global int *)_wcl_allocs->gl.access_pointer__array_min, (__global int *)_wcl_allocs->gl.access_pointer__array_max, (__global int *)_wcl_allocs->gn)));
     return *pointer;
 }
 
@@ -18,7 +18,7 @@ void set_pointed_value(
     // CHECK: _WclProgramAllocations *_wcl_allocs,
     __global int *pointer, int value)
 {
-    // CHECK: (*(_WCL_ADDR_CLAMP_global_1(__global int *, (pointer), 1, _wcl_allocs->gl.access_pointer__array_min, _wcl_allocs->gl.access_pointer__array_max, _wcl_allocs->gn))) = value;
+    // CHECK: (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((pointer), 1, (__global int *)_wcl_allocs->gl.access_pointer__array_min, (__global int *)_wcl_allocs->gl.access_pointer__array_max, (__global int *)_wcl_allocs->gn))) = value;
     *pointer = value;
 }
 

--- a/test/atomics-basic.cl
+++ b/test/atomics-basic.cl
@@ -5,24 +5,24 @@
 // check only one return argument per argument length, per argument type and per address space
 
 // long global
-// CHECK: return atomic_add(_WCL_ADDR_CLAMP_global_3(volatile __global long *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
-// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_global_3(volatile __global long *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn));
-// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_global_3(volatile __global long *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1, arg2);
+// CHECK: return atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
 
 // ulong global
-// CHECK: return atomic_add(_WCL_ADDR_CLAMP_global_3(volatile __global ulong *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
-// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_global_3(volatile __global ulong *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn));
-// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_global_3(volatile __global ulong *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1, arg2);
+// CHECK: return atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
 
 // long local
-// CHECK: return atomic_add(_WCL_ADDR_CLAMP_local_3(volatile __local long *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
-// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_local_3(volatile __local long *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln));
-// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_local_3(volatile __local long *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1, arg2);
+// CHECK: return atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
 
 // ulong local
-// CHECK: return atomic_add(_WCL_ADDR_CLAMP_local_3(volatile __local ulong *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
-// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_local_3(volatile __local ulong *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln));
-// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_local_3(volatile __local ulong *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1, arg2);
+// CHECK: return atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
 
 __kernel void atoms(volatile __global long* global_long_data, volatile __local long* local_long_data,
                       volatile __global ulong* global_ulong_data, volatile __local ulong* local_ulong_data,

--- a/test/atomics-basic.cl
+++ b/test/atomics-basic.cl
@@ -1,0 +1,86 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
+
+// check only one return argument per argument length, per argument type and per address space
+
+// long global
+// CHECK: return atomic_add(_WCL_ADDR_CLAMP_global_3(volatile __global long *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
+// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_global_3(volatile __global long *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn));
+// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_global_3(volatile __global long *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1, arg2);
+
+// ulong global
+// CHECK: return atomic_add(_WCL_ADDR_CLAMP_global_3(volatile __global ulong *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
+// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_global_3(volatile __global ulong *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn));
+// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_global_3(volatile __global ulong *, arg0, 1, _wcl_allocs->gl.atoms__global_long_data_min, _wcl_allocs->gl.atoms__global_long_data_max, _wcl_allocs->gl.atoms__global_ulong_data_min, _wcl_allocs->gl.atoms__global_ulong_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1, arg2);
+
+// long local
+// CHECK: return atomic_add(_WCL_ADDR_CLAMP_local_3(volatile __local long *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
+// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_local_3(volatile __local long *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln));
+// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_local_3(volatile __local long *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1, arg2);
+
+// ulong local
+// CHECK: return atomic_add(_WCL_ADDR_CLAMP_local_3(volatile __local ulong *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
+// CHECK: return atomic_inc(_WCL_ADDR_CLAMP_local_3(volatile __local ulong *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln));
+// CHECK: return atomic_cmpxchg(_WCL_ADDR_CLAMP_local_3(volatile __local ulong *, arg0, 1, _wcl_allocs->ll.atoms__local_long_data_min, _wcl_allocs->ll.atoms__local_long_data_max, _wcl_allocs->ll.atoms__local_ulong_data_min, _wcl_allocs->ll.atoms__local_ulong_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1, arg2);
+
+__kernel void atoms(volatile __global long* global_long_data, volatile __local long* local_long_data,
+                      volatile __global ulong* global_ulong_data, volatile __local ulong* local_ulong_data,
+                      volatile __global float* global_float_data, volatile __local float* local_float_data)
+{
+  long val_long = 1;
+  ulong val_ulong = 2;
+  ulong cmp = 1;
+
+  // CHECK: (_wcl_allocs, global_long_data, val_long);
+  val_long = atomic_add    (global_long_data, val_long);
+  // CHECK: (_wcl_allocs, global_long_data, val_long);
+  val_long = atomic_sub    (global_long_data, val_long);
+  // CHECK: (_wcl_allocs, global_long_data, val_long);
+  val_long = atomic_xchg   (global_long_data, val_long);
+  // CHECK: (_wcl_allocs, global_long_data);
+  val_long = atomic_inc    (global_long_data);
+  // CHECK: (_wcl_allocs, global_long_data);
+  val_long = atomic_dec    (global_long_data);
+  // CHECK: (_wcl_allocs, global_long_data, cmp, val_long);
+  val_long = atomic_cmpxchg(global_long_data, cmp, val_long);
+
+  // CHECK: (_wcl_allocs, global_ulong_data, val_ulong);
+  val_ulong = atomic_add    (global_ulong_data, val_ulong);
+  // CHECK: (_wcl_allocs, global_ulong_data, val_ulong);
+  val_ulong = atomic_sub    (global_ulong_data, val_ulong);
+  // CHECK: (_wcl_allocs, global_ulong_data, val_ulong);
+  val_ulong = atomic_xchg   (global_ulong_data, val_ulong);
+  // CHECK: (_wcl_allocs, global_ulong_data);
+  val_ulong = atomic_inc    (global_ulong_data);
+  // CHECK: (_wcl_allocs, global_ulong_data);
+  val_ulong = atomic_dec    (global_ulong_data);
+  // CHECK: (_wcl_allocs, global_ulong_data, cmp, val_ulong);
+  val_ulong = atomic_cmpxchg(global_ulong_data, cmp, val_ulong);
+
+  // CHECK: (_wcl_allocs, local_long_data, val_long);
+  val_long = atomic_add    (local_long_data, val_long);
+  // CHECK: (_wcl_allocs, local_long_data, val_long);
+  val_long = atomic_sub    (local_long_data, val_long);
+  // CHECK: (_wcl_allocs, local_long_data, val_long);
+  val_long = atomic_xchg   (local_long_data, val_long);
+  // CHECK: (_wcl_allocs, local_long_data);
+  val_long = atomic_inc    (local_long_data);
+  // CHECK: (_wcl_allocs, local_long_data);
+  val_long = atomic_dec    (local_long_data);
+  // CHECK: (_wcl_allocs, local_long_data, cmp, val_long);
+  val_long = atomic_cmpxchg(local_long_data, cmp, val_long);
+
+  // CHECK:  (_wcl_allocs, local_ulong_data, val_ulong);
+  val_ulong = atomic_add    (local_ulong_data, val_ulong);
+  // CHECK: (_wcl_allocs, local_ulong_data, val_ulong);
+  val_ulong = atomic_sub    (local_ulong_data, val_ulong);
+  // CHECK: (_wcl_allocs, local_ulong_data, val_ulong);
+  val_ulong = atomic_xchg   (local_ulong_data, val_ulong);
+  // CHECK: (_wcl_allocs, local_ulong_data);
+  val_ulong = atomic_inc    (local_ulong_data);
+  // CHECK: (_wcl_allocs, local_ulong_data);
+  val_ulong = atomic_dec    (local_ulong_data);
+  // CHECK: (_wcl_allocs, local_ulong_data, cmp, val_ulong);
+  val_ulong = atomic_cmpxchg(local_ulong_data, cmp, val_ulong);
+}

--- a/test/atomics-extended.cl
+++ b/test/atomics-extended.cl
@@ -1,0 +1,71 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+#pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
+
+// check only one return argument per argument length, per argument type and per address space
+
+// int global
+// CHECK: return atomic_min(_WCL_ADDR_CLAMP_global_3(volatile __global int *, arg0, 1, _wcl_allocs->gl.atoms__global_int_data_min, _wcl_allocs->gl.atoms__global_int_data_max, _wcl_allocs->gl.atoms__global_uint_data_min, _wcl_allocs->gl.atoms__global_uint_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
+
+// uint global
+// CHECK: return atomic_min(_WCL_ADDR_CLAMP_global_3(volatile __global uint *, arg0, 1, _wcl_allocs->gl.atoms__global_int_data_min, _wcl_allocs->gl.atoms__global_int_data_max, _wcl_allocs->gl.atoms__global_uint_data_min, _wcl_allocs->gl.atoms__global_uint_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
+
+// int local
+// CHECK: return atomic_min(_WCL_ADDR_CLAMP_local_3(volatile __local int *, arg0, 1, _wcl_allocs->ll.atoms__local_int_data_min, _wcl_allocs->ll.atoms__local_int_data_max, _wcl_allocs->ll.atoms__local_uint_data_min, _wcl_allocs->ll.atoms__local_uint_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
+
+// uint local
+// CHECK: return atomic_min(_WCL_ADDR_CLAMP_local_3(volatile __local uint *, arg0, 1, _wcl_allocs->ll.atoms__local_int_data_min, _wcl_allocs->ll.atoms__local_int_data_max, _wcl_allocs->ll.atoms__local_uint_data_min, _wcl_allocs->ll.atoms__local_uint_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
+
+__kernel void atoms(volatile __global int* global_int_data, volatile __local int* local_int_data,
+                      volatile __global uint* global_uint_data, volatile __local uint* local_uint_data,
+                      volatile __global float* global_float_data, volatile __local float* local_float_data)
+{
+  int val_int = 1;
+  int val_uint = 2;
+  uint cmp = 1;
+  float val_float = 3;
+
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_min    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_max    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_and    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_or     (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_xor    (global_int_data, val_int);
+
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_min    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_max    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_and    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_or     (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_xor    (global_uint_data, val_uint);
+
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_min    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_max    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_and    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_or     (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_xor    (local_int_data, val_int);
+
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_min    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_max    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_and    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_or     (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_xor    (local_uint_data, val_uint);
+}

--- a/test/atomics-extended.cl
+++ b/test/atomics-extended.cl
@@ -5,16 +5,16 @@
 // check only one return argument per argument length, per argument type and per address space
 
 // int global
-// CHECK: return atomic_min(_WCL_ADDR_CLAMP_global_3(volatile __global int *, arg0, 1, _wcl_allocs->gl.atoms__global_int_data_min, _wcl_allocs->gl.atoms__global_int_data_max, _wcl_allocs->gl.atoms__global_uint_data_min, _wcl_allocs->gl.atoms__global_uint_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
+// CHECK: return atomic_min(_
 
 // uint global
-// CHECK: return atomic_min(_WCL_ADDR_CLAMP_global_3(volatile __global uint *, arg0, 1, _wcl_allocs->gl.atoms__global_int_data_min, _wcl_allocs->gl.atoms__global_int_data_max, _wcl_allocs->gl.atoms__global_uint_data_min, _wcl_allocs->gl.atoms__global_uint_data_max, _wcl_allocs->gl.atoms__global_float_data_min, _wcl_allocs->gl.atoms__global_float_data_max, _wcl_allocs->gn), arg1);
+// CHECK: return atomic_min(_
 
 // int local
-// CHECK: return atomic_min(_WCL_ADDR_CLAMP_local_3(volatile __local int *, arg0, 1, _wcl_allocs->ll.atoms__local_int_data_min, _wcl_allocs->ll.atoms__local_int_data_max, _wcl_allocs->ll.atoms__local_uint_data_min, _wcl_allocs->ll.atoms__local_uint_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
+// CHECK: return atomic_min(_
 
 // uint local
-// CHECK: return atomic_min(_WCL_ADDR_CLAMP_local_3(volatile __local uint *, arg0, 1, _wcl_allocs->ll.atoms__local_int_data_min, _wcl_allocs->ll.atoms__local_int_data_max, _wcl_allocs->ll.atoms__local_uint_data_min, _wcl_allocs->ll.atoms__local_uint_data_max, _wcl_allocs->ll.atoms__local_float_data_min, _wcl_allocs->ll.atoms__local_float_data_max, _wcl_allocs->ln), arg1);
+// CHECK: return atomic_min(_
 
 __kernel void atoms(volatile __global int* global_int_data, volatile __local int* local_int_data,
                       volatile __global uint* global_uint_data, volatile __local uint* local_uint_data,

--- a/test/atomics.cl
+++ b/test/atomics.cl
@@ -1,0 +1,136 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+// check only one return argument per argument length, per argument type and per address space
+
+// int global
+// CHECK: return atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
+
+// uint global
+// CHECK: atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
+
+// int local
+// CHECK: return atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
+
+// uint local
+// CHECK: return atomic_add(_
+// CHECK: return atomic_inc(_
+// CHECK: return atomic_cmpxchg(_
+
+// float global
+// CHECK: return atomic_xchg(_
+
+// float local
+// CHECK: return atomic_xchg(_
+
+__kernel void atomics(volatile __global int* global_int_data, volatile __local int* local_int_data,
+                      volatile __global uint* global_uint_data, volatile __local uint* local_uint_data,
+                      volatile __global float* global_float_data, volatile __local float* local_float_data)
+{
+  int val_int = 1;
+  int val_uint = 2;
+  uint cmp = 1;
+  float val_float = 3;
+
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_add    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_sub    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_xchg   (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data);
+  val_int = atomic_inc    (global_int_data);
+  // CHECK: (_wcl_allocs, global_int_data);
+  val_int = atomic_dec    (global_int_data);
+  // CHECK: (_wcl_allocs, global_int_data, cmp, val_int);
+  val_int = atomic_cmpxchg(global_int_data, cmp, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_min    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_max    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_and    (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_or     (global_int_data, val_int);
+  // CHECK: (_wcl_allocs, global_int_data, val_int);
+  val_int = atomic_xor    (global_int_data, val_int);
+
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_add    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_sub    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_xchg   (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data);
+  val_uint = atomic_inc    (global_uint_data);
+  // CHECK: (_wcl_allocs, global_uint_data);
+  val_uint = atomic_dec    (global_uint_data);
+  // CHECK: (_wcl_allocs, global_uint_data, cmp, val_uint);
+  val_uint = atomic_cmpxchg(global_uint_data, cmp, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_min    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_max    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_and    (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_or     (global_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, global_uint_data, val_uint);
+  val_uint = atomic_xor    (global_uint_data, val_uint);
+
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_add    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_sub    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_xchg   (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data);
+  val_int = atomic_inc    (local_int_data);
+  // CHECK: (_wcl_allocs, local_int_data);
+  val_int = atomic_dec    (local_int_data);
+  // CHECK: (_wcl_allocs, local_int_data, cmp, val_int);
+  val_int = atomic_cmpxchg(local_int_data, cmp, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_min    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_max    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_and    (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_or     (local_int_data, val_int);
+  // CHECK: (_wcl_allocs, local_int_data, val_int);
+  val_int = atomic_xor    (local_int_data, val_int);
+
+  // CHECK:  (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_add    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_sub    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_xchg   (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data);
+  val_uint = atomic_inc    (local_uint_data);
+  // CHECK: (_wcl_allocs, local_uint_data);
+  val_uint = atomic_dec    (local_uint_data);
+  // CHECK: (_wcl_allocs, local_uint_data, cmp, val_uint);
+  val_uint = atomic_cmpxchg(local_uint_data, cmp, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_min    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_max    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_and    (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_or     (local_uint_data, val_uint);
+  // CHECK: (_wcl_allocs, local_uint_data, val_uint);
+  val_uint = atomic_xor    (local_uint_data, val_uint);
+
+  // CHECK: (_wcl_allocs, global_float_data, val_float);
+  val_float = atomic_xchg(global_float_data, val_float);
+  // CHECK: (_wcl_allocs, local_float_data, val_float);
+  val_float = atomic_xchg(local_float_data, val_float);
+}

--- a/test/builtin-vload-indirect.cl
+++ b/test/builtin-vload-indirect.cl
@@ -17,15 +17,15 @@ __kernel void builtin_wrappers(__global char *output,
     }
 
     offset = 0;
-    // CHECK: float4 r1 = _wcl_vload4_0(_wcl_allocs, _wcl_locals._wcl_offset, ((*(_WCL_ADDR_CLAMP_private_1(__global float **, (_wcl_allocs->pa._wcl_ptr), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))));
+    // CHECK: float4 r1 = _wcl_vload4_0(_wcl_allocs, _wcl_locals._wcl_offset,
     float4 r1 = vload4(offset, (*ptr));
 
     offset = 1;
-    // CHECK: float4 r2 = _wcl_vload4_1(_wcl_allocs, _wcl_locals._wcl_offset, ((*(_WCL_ADDR_CLAMP_private_1(__global float **, (_wcl_allocs->pa._wcl_ptr), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))));
+    // CHECK: float4 r2 = _wcl_vload4_1(_wcl_allocs, _wcl_locals._wcl_offset,
     float4 r2 = vload4(offset, (*ptr));
 
     offset = 2;
-    // CHECK: float4 r3 = _wcl_vload4_2(_wcl_allocs, _wcl_locals._wcl_offset, ((*(_WCL_ADDR_CLAMP_private_1(__global float **, (_wcl_allocs->pa._wcl_ptr), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))));
+    // CHECK: float4 r3 = _wcl_vload4_2(_wcl_allocs, _wcl_locals._wcl_offset,
     float4 r3 = vload4(offset, (*ptr));
 
     output[0] = r1.x;

--- a/test/extension-enable.cl
+++ b/test/extension-enable.cl
@@ -5,9 +5,9 @@
 
 // CHECK-NOT: error: WebCL doesn't support enabling 'cl_khr_fp64' extension.
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-// CHECK: error: WebCL doesn't support enabling 'cl_khr_int64_base_atomics' extension.
+// CHECK-NOT: error: WebCL doesn't support enabling 'cl_khr_int64_base_atomics' extension.
 #pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
-// CHECK: error: WebCL doesn't support enabling 'cl_khr_int64_extended_atomics' extension.
+// CHECK-NOT: error: WebCL doesn't support enabling 'cl_khr_int64_extended_atomics' extension.
 #pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
 // CHECK-NOT: error: WebCL doesn't support enabling 'cl_khr_fp16' extension.
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable

--- a/test/transform-array-index.cl
+++ b/test/transform-array-index.cl
@@ -9,16 +9,16 @@ __kernel void transform_array_index(
     const int i = get_global_id(0);
 
     int pair[2] = { 0, 0 };
-    // CHECK: (*(_WCL_ADDR_CLAMP_private_1(int *, (_wcl_allocs->pa._wcl_pair)+(i + 0), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn))) = 0;
+    // CHECK: (*(_wcl_addr_clamp_private_1_int__Ptr((_wcl_allocs->pa._wcl_pair)+(i + 0), 1, (int *)&_wcl_allocs->pa, (int *)(&_wcl_allocs->pa + 1), (int *)_wcl_allocs->pn))) = 0;
     pair[i + 0] = 0;
-    // CHECK: (*(_WCL_ADDR_CLAMP_private_1(int *, (_wcl_allocs->pa._wcl_pair)+((i + 1)), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn))) = 1;
+    // CHECK: (*(_wcl_addr_clamp_private_1_int__Ptr((_wcl_allocs->pa._wcl_pair)+((i + 1)), 1, (int *)&_wcl_allocs->pa, (int *)(&_wcl_allocs->pa + 1), (int *)_wcl_allocs->pn))) = 1;
 #ifndef __PLATFORM_AMD__
     (i + 1)[pair] = 1;
 #endif
 
-    // CHECK: (*(_WCL_ADDR_CLAMP_global_1(__global int *, (array)+(i), 1, _wcl_allocs->gl.transform_array_index__array_min, _wcl_allocs->gl.transform_array_index__array_max, _wcl_allocs->gn))) = (*(_WCL_ADDR_CLAMP_private_1(int *, (_wcl_allocs->pa._wcl_pair)+(i + 0), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))
+    // CHECK: (*(_wcl_addr_clamp_global_1__u_uglobal__int__Ptr((array)+(i), 1, (__global int *)_wcl_allocs->gl.transform_array_index__array_min, (__global int *)_wcl_allocs->gl.transform_array_index__array_max, (__global int *)_wcl_allocs->gn))) = (*(_wcl_addr_clamp_private_1_int__Ptr((_wcl_allocs->pa._wcl_pair)+(i + 0), 1, (int *)&_wcl_allocs->pa, (int *)(&_wcl_allocs->pa + 1), (int *)_wcl_allocs->pn)))
     array[i] = pair[i + 0]
-    // CHECK: + (*(_WCL_ADDR_CLAMP_private_1(int *, (_wcl_allocs->pa._wcl_pair)+((i + 1)), 1, &_wcl_allocs->pa, (&_wcl_allocs->pa + 1), _wcl_allocs->pn)))
+    // CHECK: + (*(_wcl_addr_clamp_private_1_int__Ptr((_wcl_allocs->pa._wcl_pair)+((i + 1)), 1, (int *)&_wcl_allocs->pa, (int *)(&_wcl_allocs->pa + 1), (int *)_wcl_allocs->pn)))
 #ifndef __PLATFORM_AMD__
         + (i + 1)[pair]
 #endif

--- a/test/unsafe-builtins.cl
+++ b/test/unsafe-builtins.cl
@@ -9,13 +9,6 @@ __kernel void unsafe_builtins(
     __constant float *input,
     __global float *output)
 {
-    const size_t i = get_global_id(0);
-
-    __local int offset;
-    offset = i;
-    // CHECK: error: Builtin argument check is required.
-    offset = atomic_add(&offset, 1);
-
     float x_floor;
     // CHECK: error: Builtin argument check is required.
     float x_fract = fract(x, &x_floor);

--- a/test/unsafe-builtins.cl
+++ b/test/unsafe-builtins.cl
@@ -1,5 +1,11 @@
-// RUN: %opencl-validator < %s
-// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+#ifdef cl_khr_fp16
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#endif
+#ifdef cl_khr_fp64
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#endif
+
+// RUN: %webcl-validator %s -Dcl_khr_fp16 -Dcl_khr_fp64 2>&1 | grep -v CHECK | %FileCheck %s
 
 // We should be declaring all builtins at the moment
 // CHECK-NOT: warning: implicit declaration of function
@@ -9,7 +15,34 @@ __kernel void unsafe_builtins(
     __constant float *input,
     __global float *output)
 {
-    float x_floor;
-    // CHECK: error: Builtin argument check is required.
-    float x_fract = fract(x, &x_floor);
+    float y, z, f;
+    int i;
+    int2 i2;
+    half2 h2;
+    double2 d2;
+
+    // CHECK: _wcl_frac
+    f = fract(x, &y);
+    // CHECK: _wcl_frac
+    d2 = fract(d2, &d2);
+    // CHECK: _wcl_frexp
+    f = frexp(x, &i);
+    // CHECK: _wcl_frexp
+    h2 = frexp(h2, &i2);
+    // CHECK: _wcl_frexp
+    d2 = frexp(d2, &i2);
+    // CHECK: _wcl_modf
+    f = modf(x, &y);
+    // CHECK: _wcl_lgamma_r
+    f = lgamma_r(x, &i);
+    // CHECK: _wcl_lgamma_r
+    h2 = lgamma_r(h2, &i2);
+    // CHECK: _wcl_lgamma_r
+    d2 = lgamma_r(d2, &i2);
+    // CHECK: _wcl_remquo
+    f = remquo(x, z, &i);
+    // CHECK: _wcl_remquo
+    h2 = remquo(h2, h2, &i2);
+    // CHECK: _wcl_remquo
+    d2 = remquo(d2, d2, &i2);
 }


### PR DESCRIPTION
This pull-request is of three consecutive branches: erkkise/use_tr1_shared_ptr, erkkise/atomics and erkkise/functions_for_macros.

erkkise/use_tr1_shared_ptr:

Use shared ptr from tr1 to keep code compiling on c++03 -based compilers (still the default for clang).

erkkise/atomics: Fixes issue #82.

Implement atomics and remaining mathematics functions involving pointers (fract, frexp, modf, lgamma_r, remquo). This is implemented using the same mechanism as the wrapping of vload and vstore by providing a general wrapper for any function that takes exactly one pointer to one value.

erkkise/functions_for_macros:

Replaced generation of clamping and checking macros with functions. This overcomes the problem of side-effectful expressions being evaluated multiple times.

Instead of passing type as an argument to the macro, each different type gets its own function. The name of the type is embedded into the name of the clamping/checking function by using a new function WebCLConfiguration::getIdentifierOfString which is a mangling function of sorts. The function makes sure the user is not able to introduce collisions for types that are named differently.
