### PR TITLE
Disallow function with declaration but no implementation

### DIFF
--- a/lib/WebCLDiag.cpp
+++ b/lib/WebCLDiag.cpp
@@ -51,7 +51,7 @@ namespace
 {
     bool collectSourceLocation(
         const clang::Diagnostic &info,
-        std::map<clang::FileID, std::shared_ptr<std::string> > &sources,
+        std::map<clang::FileID, std::tr1::shared_ptr<std::string> > &sources,
         WebCLDiag::Message &message)
     {
         clang::SourceLocation loc = info.getLocation();
@@ -71,7 +71,7 @@ namespace
             if (invalid)
                 return false;
 
-            sources[file] = std::shared_ptr<std::string>(new std::string(source));
+            sources[file] = std::tr1::shared_ptr<std::string>(new std::string(source));
         }
 
         message.source = sources[file];

--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -24,7 +24,7 @@
 #include "clang/Basic/Diagnostic.h"
 
 #include <map>
-#include <memory>
+#include <tr1/memory>
 #include <string>
 #include <vector>
 
@@ -50,13 +50,13 @@ public:
         clang::DiagnosticsEngine::Level level;
         std::string text;
 
-        std::shared_ptr<std::string> source;
+        std::tr1::shared_ptr<std::string> source;
         std::string::size_type sourceOffset;
         std::string::size_type sourceLen;
 
         Message(clang::DiagnosticsEngine::Level level)
             : level(level)
-            , source(NULL), sourceOffset(std::string::npos), sourceLen(std::string::npos)
+            , source(), sourceOffset(std::string::npos), sourceLen(std::string::npos)
         {
         }
     };
@@ -65,5 +65,5 @@ public:
 
 private:
 
-    std::map<clang::FileID, std::shared_ptr<std::string> > sources;
+    std::map<clang::FileID, std::tr1::shared_ptr<std::string> > sources;
 };

--- a/lib/WebCLPass.cpp
+++ b/lib/WebCLPass.cpp
@@ -82,7 +82,10 @@ void WebCLHelperFunctionHandler::run(clang::ASTContext &context)
     WebCLAnalyser::FunctionDeclSet &helperFunctions = analyser_.getHelperFunctions();
     for (WebCLAnalyser::FunctionDeclSet::iterator i = helperFunctions.begin();
         i != helperFunctions.end(); ++i) {
-            transformer_.addRecordParameter(*i);
+        if (!(*i)->hasBody()) {
+            error((*i)->getLocStart(), "All declared functions must be defined");
+        }
+        transformer_.addRecordParameter(*i);
     }
 
     // Go through all helper function calls and add allocation
@@ -90,7 +93,7 @@ void WebCLHelperFunctionHandler::run(clang::ASTContext &context)
     WebCLAnalyser::CallExprSet &internalCalls = analyser_.getInternalCalls();
     for (WebCLAnalyser::CallExprSet::iterator i = internalCalls.begin();
         i != internalCalls.end(); ++i) {
-            transformer_.addRecordArgument(*i);
+        transformer_.addRecordArgument(*i);
     }
 }
 

--- a/test/declared-functions.cl
+++ b/test/declared-functions.cl
@@ -1,0 +1,13 @@
+// RUN: %webcl-validator %s 2>/dev/null
+
+void foo(void);
+
+__kernel void declared_function_test(void)
+{
+  foo();
+}
+
+void foo(void) {
+  // ok
+}
+

--- a/test/memcpy.cl
+++ b/test/memcpy.cl
@@ -1,0 +1,13 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+// CHECK: error: All declared functions must be defined
+void memcpy(long dest, size_t n);
+
+// CHECK: error: All declared functions must be defined
+void some_other_fn(void* ptr);
+
+__kernel void memcpy_test(void)
+{
+  char buffer[4];
+  memcpy((int) buffer, 4);
+}


### PR DESCRIPTION
Requires that when a function is declared, a definition for it must exist. This prevents one from declaring (say) memcpy, not defining it, and then calling possibly system-provided implementation of it. This could allow accessing arbitrary memory. Fixes #77.

Based on top of the std::tr1::shared_ptr fix.
