### PR TITLE
atomics-basic, extended.cl: fixed tests in the same way as the fix for atomics.cl

### DIFF
--- a/test/atomics-basic.cl
+++ b/test/atomics-basic.cl
@@ -5,24 +5,24 @@
 // check only one return argument per argument length, per argument type and per address space
 
 // long global
-// CHECK: return atomic_add(_
-// CHECK: return atomic_inc(_
-// CHECK: return atomic_cmpxchg(_
+// CHECK-DAG: return atomic_add(_
+// CHECK-DAG: return atomic_inc(_
+// CHECK-DAG: return atomic_cmpxchg(_
 
 // ulong global
-// CHECK: return atomic_add(_
-// CHECK: return atomic_inc(_
-// CHECK: return atomic_cmpxchg(_
+// CHECK-DAG: return atomic_add(_
+// CHECK-DAG: return atomic_inc(_
+// CHECK-DAG: return atomic_cmpxchg(_
 
 // long local
-// CHECK: return atomic_add(_
-// CHECK: return atomic_inc(_
-// CHECK: return atomic_cmpxchg(_
+// CHECK-DAG: return atomic_add(_
+// CHECK-DAG: return atomic_inc(_
+// CHECK-DAG: return atomic_cmpxchg(_
 
 // ulong local
-// CHECK: return atomic_add(_
-// CHECK: return atomic_inc(_
-// CHECK: return atomic_cmpxchg(_
+// CHECK-DAG: return atomic_add(_
+// CHECK-DAG: return atomic_inc(_
+// CHECK-DAG: return atomic_cmpxchg(_
 
 __kernel void atoms(volatile __global long* global_long_data, volatile __local long* local_long_data,
                       volatile __global ulong* global_ulong_data, volatile __local ulong* local_ulong_data,

--- a/test/atomics-extended.cl
+++ b/test/atomics-extended.cl
@@ -5,16 +5,16 @@
 // check only one return argument per argument length, per argument type and per address space
 
 // int global
-// CHECK: return atomic_min(_
+// CHECK-DAG: return atomic_min(_
 
 // uint global
-// CHECK: return atomic_min(_
+// CHECK-DAG: return atomic_min(_
 
 // int local
-// CHECK: return atomic_min(_
+// CHECK-DAG: return atomic_min(_
 
 // uint local
-// CHECK: return atomic_min(_
+// CHECK-DAG: return atomic_min(_
 
 __kernel void atoms(volatile __global int* global_int_data, volatile __local int* local_int_data,
                       volatile __global uint* global_uint_data, volatile __local uint* local_uint_data,


### PR DESCRIPTION
So: by using CHECK-DAG for the checks before __kernel.
