### PR TITLE
WebCLRestrictor: prohibit the use of goto

### DIFF
--- a/lib/WebCLVisitor.cpp
+++ b/lib/WebCLVisitor.cpp
@@ -112,6 +112,11 @@ bool WebCLVisitor::VisitForStmt(clang::ForStmt *stmt)
   return handleForStmt(stmt);
 }
 
+bool WebCLVisitor::VisitGotoStmt(clang::GotoStmt *stmt)
+{
+    return handleGotoStmt(stmt);
+}
+
 bool WebCLVisitor::handleTranslationUnitDecl(clang::TranslationUnitDecl *decl)
 {
     return true;
@@ -180,6 +185,10 @@ bool WebCLVisitor::handleForStmt(clang::ForStmt *stmt) {
   return true;
 }
 
+bool WebCLVisitor::handleGotoStmt(clang::GotoStmt *stmt) {
+  return true;
+}
+
 // WebCLRestrictor
 
 WebCLRestrictor::WebCLRestrictor(clang::CompilerInstance &instance)
@@ -222,6 +231,12 @@ bool WebCLRestrictor::handleParmVarDecl(clang::ParmVarDecl *decl)
     check3dImageParameter(function, typeLocation, type);
     checkUnsupportedBuiltinParameter(function, typeLocation, qualType);
     return true;
+}
+
+bool WebCLRestrictor::handleGotoStmt(clang::GotoStmt *stmt)
+{
+    error(stmt->getLocStart(), "WebCL does not support goto");
+    return false;
 }
 
 void WebCLRestrictor::checkStructureParameter(

--- a/lib/WebCLVisitor.hpp
+++ b/lib/WebCLVisitor.hpp
@@ -87,6 +87,8 @@ public:
     bool VisitDeclRefExpr(clang::DeclRefExpr *decl);
     /// \see clang::RecursiveASTVisitor::VisitForStmt
     bool VisitForStmt(clang::ForStmt *stmt);
+    /// \see clang::RecursiveASTVisitor::VisitGotoStmt
+    bool VisitGotoStmt(clang::GotoStmt *stmt);
   
 protected:
 
@@ -106,6 +108,7 @@ protected:
     virtual bool handleRecordDecl(clang::RecordDecl *decl);
     virtual bool handleDeclRefExpr(clang::DeclRefExpr *expr);
     virtual bool handleForStmt(clang::ForStmt *stmt);
+    virtual bool handleGotoStmt(clang::GotoStmt *stmt);
 };
 
 /// \brief Complains about WebCL limitations in OpenCL C code.
@@ -118,6 +121,9 @@ public:
 
     /// \see WebCLVisitor::handleParmVar
     virtual bool handleParmVarDecl(clang::ParmVarDecl *decl);
+
+    /// \see WebCLVisitor::handleGotoStmt
+    virtual bool handleGotoStmt(clang::GotoStmt *stmt);
 
 private:
 

--- a/test/goto.cl
+++ b/test/goto.cl
@@ -1,0 +1,8 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+__kernel void goto_test(void)
+{
+ label:
+  // CHECK: error: WebCL does not support goto
+  goto label;
+}

--- a/test/goto2.cl
+++ b/test/goto2.cl
@@ -1,0 +1,10 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+
+#define paste(X, Y) X##Y
+
+__kernel void goto2_test(void)
+{
+ label:
+  // CHECK: error: WebCL does not support goto
+  paste(go,to) label;
+}


### PR DESCRIPTION
Fixes #76.
