### PR TITLE
WebCLHelperFunctionHandler: disallow non-called functions that have no body

### DIFF
--- a/lib/WebCLPass.hpp
+++ b/lib/WebCLPass.hpp
@@ -276,7 +276,7 @@ private:
     WebCLKernelHandler &kernelHandler_;
 };
 
-/// Generates memory access checks.
+/// Generates memory access checks and disallows calls to undeclared functions.
 class WebCLFunctionCallHandler : public WebCLPass
 {
 public:

--- a/test/declared-functions.cl
+++ b/test/declared-functions.cl
@@ -1,6 +1,10 @@
 // RUN: %webcl-validator %s 2>/dev/null
 
+// ok, defined later
 void foo(void);
+
+// ok, not called
+void foo2(void);
 
 __kernel void declared_function_test(void)
 {

--- a/test/memcpy.cl
+++ b/test/memcpy.cl
@@ -1,13 +1,13 @@
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 
-// CHECK: error: All declared functions must be defined
 void memcpy(long dest, size_t n);
 
-// CHECK: error: All declared functions must be defined
+// CHECK-NOT: error: All declared functions that are called must be defined
 void some_other_fn(void* ptr);
 
 __kernel void memcpy_test(void)
 {
   char buffer[4];
+  // CHECK: error: All declared functions that are called must be defined
   memcpy((int) buffer, 4);
 }


### PR DESCRIPTION
This refines the previous fix for #77 by allowing to declare functions
that are not called, thus allowing more code to be compiled without
introducing security problems.

The check is also now performed in WebCLFunctionCallHandler which
seems more appproriate instead of in WebCLHelperFunctionHandler.
