### PR TITLE
Avoid using std::shared_ptr in WebCLDiag

### DIFF
--- a/lib/WebCLDiag.hpp
+++ b/lib/WebCLDiag.hpp
@@ -24,7 +24,6 @@
 #include "clang/Basic/Diagnostic.h"
 
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -50,13 +49,13 @@ public:
         clang::DiagnosticsEngine::Level level;
         std::string text;
 
-        std::shared_ptr<std::string> source;
+        std::string *source;
         std::string::size_type sourceOffset;
         std::string::size_type sourceLen;
 
         Message(clang::DiagnosticsEngine::Level level)
             : level(level)
-            , source(), sourceOffset(std::string::npos), sourceLen(std::string::npos)
+            , source(NULL), sourceOffset(std::string::npos), sourceLen(std::string::npos)
         {
         }
     };
@@ -65,5 +64,11 @@ public:
 
 private:
 
-    std::map<clang::FileID, std::shared_ptr<std::string> > sources;
+    bool collectSourceLocation(
+        const clang::Diagnostic &info,
+        WebCLDiag::Message &message);
+
+    int nextSourceID;
+    std::map<clang::FileID, int /* sourceID */> sourceIDs;
+    std::map<int /* sourceID */, std::string> sources;
 };

--- a/lib/clv.cpp
+++ b/lib/clv.cpp
@@ -333,7 +333,7 @@ CLV_API extern "C" cl_bool CLV_CALL clvProgramLogMessageHasSource(
     if (n >= messages.size())
         return CL_FALSE;
 
-    return messages[n].source.get() != NULL;
+    return messages[n].source != NULL;
 }
 
 CLV_API extern "C" cl_long CLV_CALL clvGetProgramLogMessageSourceOffset(


### PR DESCRIPTION
Instead, the std::strings are stored as std::map values. std::map
guarantees that pointers to values will remain valid even if other items
are inserted. We need two maps because we need to invalidate the FileID
map on SourceManager changes but still need to keep the std::strings
for old source files with log messages alive.
