### PR TITLE
Fix #66: write_imagei/ui/f checked for valid range

### DIFF
--- a/lib/WebCLPass.cpp
+++ b/lib/WebCLPass.cpp
@@ -316,7 +316,8 @@ void WebCLKernelHandler::run(clang::ASTContext &context)
             for (std::vector<WebCLAnalyser::KernelArgInfo>::const_iterator j = i->args.begin();
                 j != i->args.end(); ++j) {
                     const WebCLAnalyser::KernelArgInfo &parm = *j;
-                    if (parm.pointerKind != WebCLTypes::NOT_POINTER) {
+                    if (parm.pointerKind != WebCLTypes::NOT_POINTER &&
+                        parm.pointerKind != WebCLTypes::IMAGE_HANDLE) {
 
                         transformer_.addSizeParameter(parm.decl);
 

--- a/lib/kernel.cl
+++ b/lib/kernel.cl
@@ -1948,10 +1948,9 @@ void _CL_OVERLOADABLE write_imagei (image2d_t image, int2 coord, int4 color);
 
 void _CL_OVERLOADABLE write_imageui (image2d_t image, int2 coord, uint4 color);
 
-/* not implemented 
 void _CL_OVERLOADABLE write_imagef (image2d_t image, int2 coord,
                                     float4 color);
-
+/* not implemented 
 void _CL_OVERLOADABLE write_imagef (image2d_array_t image, int4 coord,
                                     float4 color);
 

--- a/test/include/kernelargs.hpp
+++ b/test/include/kernelargs.hpp
@@ -74,6 +74,12 @@ public:
         }
     }
 
+    void appendImage(cl_mem image) {
+        cl_int ret = clSetKernelArg(kernel_, argi_++, sizeof(image), &image);
+        if (ret != CL_SUCCESS)
+            std::cerr << "clSetKernelArg failed for cl_mem (image)." << std::endl;
+    }
+
     void appendInt(cl_int val) {
         cl_int ret = clSetKernelArg(kernel_, argi_++, sizeof(val), &val);
         if (ret != CL_SUCCESS)

--- a/test/write-image.cl
+++ b/test/write-image.cl
@@ -1,0 +1,32 @@
+// RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
+// RUN: %webcl-validator %s | kernel-runner --webcl --kernel write_image --image 10 10 | grep '9 (0.00, 9.00, 3.00, 4.00), (1.00, 9.00, 3.00, 4.00), (2.00, 9.00, 3.00, 4.00), (3.00, 9.00, 3.00, 4.00), (4.00, 9.00, 3.00, 4.00), (5.00, 9.00, 3.00, 4.00), (6.00, 9.00, 3.00, 4.00), (7.00, 9.00, 3.00, 4.00), (8.00, 9.00, 3.00, 4.00), (9.00, 9.00, 3.00, 4.00)'
+// RUN: ! (cat %s | kernel-runner --opencl --kernel write_image --image 10 10)
+__kernel void write_image(
+    __global char* output,
+    write_only image2d_t image)
+{
+    // CHECK:  _wcl_write_imagei
+    write_imagei(image, (int2)(0, 0), (int4)(1, 2, 3, 4));
+    // CHECK:  _wcl_write_imageui
+    write_imageui(image, (int2)(0, 0), (uint4)(1, 2, 3, 4));
+    // CHECK:  _wcl_write_imagef
+    write_imagef(image, (int2)(0, 0), (float4)(1, 2, 3, 4));
+
+    for (int y = 0; y < 10; ++y) {
+        for (int x = 0; x < 10; ++x) {
+            write_imagef(image, (int2)(x, y), (float4)(x, y, 3, 4));
+        }
+    }
+
+    for (int y = 10; y < 10000; ++y) {
+        for (int x = 10; x < 10000; ++x) {
+            write_imagef(image, (int2)(x, y), (float4)(x, y, 3, 4));
+        }
+    }
+
+    for (int y = -10; y > -10000; --y) {
+        for (int x = -10; x > -10000; --x) {
+            write_imagef(image, (int2)(x, y), (float4)(x, y, 3, 4));
+        }
+    }
+}


### PR DESCRIPTION
- write_imagef/u/i are now wrapped with a function that checks that the arguments are properly bounded.
- Adds support to kernel-runner for images that are written by the kernel (no read support yet).
- Fixes an issue with generating kernel function arguments with image parameters.
