### PR TITLE
Fix missing image qualifiers when generating wrapping checker code

### DIFF
--- a/lib/WebCLPass.cpp
+++ b/lib/WebCLPass.cpp
@@ -728,23 +728,10 @@ WebCLImageSamplerSafetyHandler::WebCLImageSamplerSafetyHandler(
     checkedTypes_["sampler_t"] = new TypeAccessCheckerSampler;
 }
 
-namespace {
-    clang::DeclRefExpr *declRefExprViaImplicit(clang::Expr *expr)
-    {
-        clang::DeclRefExpr *declRefExpr = clang::dyn_cast<clang::DeclRefExpr>(expr);
-        if (!declRefExpr) {
-            if (clang::ImplicitCastExpr *implicitCastExpr = clang::dyn_cast<clang::ImplicitCastExpr>(expr)) {
-                declRefExpr = clang::dyn_cast<clang::DeclRefExpr>(*implicitCastExpr->child_begin());
-            }
-        }
-        return declRefExpr;
-    }
-}
-
 void WebCLImageSamplerSafetyHandler::run(clang::ASTContext &context)
 {
     WebCLAnalyser::CallExprSet calls = analyser_.getBuiltinCalls();
-    std::set<clang::DeclRefExpr*> usedAsArgument;
+    std::set<const clang::DeclRefExpr*> usedAsArgument;
 
     calls.insert(analyser_.getInternalCalls().begin(), analyser_.getInternalCalls().end());
 
@@ -771,7 +758,7 @@ void WebCLImageSamplerSafetyHandler::run(clang::ASTContext &context)
                     SAFE
                 } safety = REFERENCE_NOT_FOUND;
 
-                clang::DeclRefExpr *declRefExpr = declRefExprViaImplicit(expr);
+                const clang::DeclRefExpr *declRefExpr = WebCLTypes::declRefExprViaImplicit(expr);
 
                 std::string errorMessage;
                 if (declRefExpr) {
@@ -817,7 +804,7 @@ void WebCLImageSamplerSafetyHandler::run(clang::ASTContext &context)
         }
     }
 
-    std::set<clang::DeclRefExpr*> usedAsInitializer;
+    std::set<const clang::DeclRefExpr*> usedAsInitializer;
 
     WebCLAnalyser::VarDeclSet varDecls = analyser_.getLocalVariables();
     varDecls.insert(analyser_.getConstantVariables().begin(), analyser_.getConstantVariables().end());
@@ -828,7 +815,7 @@ void WebCLImageSamplerSafetyHandler::run(clang::ASTContext &context)
         clang::VarDecl *varDecl = *varDeclIt;
         clang::Expr *expr = varDecl->getInit();
         if (expr) {
-            clang::DeclRefExpr *declRefExpr = declRefExprViaImplicit(expr);
+            const clang::DeclRefExpr *declRefExpr = WebCLTypes::declRefExprViaImplicit(expr);
             if (declRefExpr) {
                 usedAsInitializer.insert(declRefExpr);
             }

--- a/lib/WebCLTypes.cpp
+++ b/lib/WebCLTypes.cpp
@@ -294,4 +294,15 @@ namespace WebCLTypes {
         }
         return kind;
     }
+
+    const clang::DeclRefExpr *declRefExprViaImplicit(const clang::Expr *expr)
+    {
+        const clang::DeclRefExpr *declRefExpr = clang::dyn_cast<clang::DeclRefExpr>(expr);
+        if (!declRefExpr) {
+            if (const clang::ImplicitCastExpr *implicitCastExpr = clang::dyn_cast<const clang::ImplicitCastExpr>(expr)) {
+                declRefExpr = clang::dyn_cast<const clang::DeclRefExpr>(*implicitCastExpr->child_begin());
+            }
+        }
+        return declRefExpr;
+    }
 }

--- a/lib/WebCLTypes.hpp
+++ b/lib/WebCLTypes.hpp
@@ -25,6 +25,7 @@
 */
 
 #include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
 
 #include <map>
 #include <set>
@@ -91,6 +92,10 @@ namespace WebCLTypes {
     /// Works around a bug in Clang's vector element access
     /// expression.
     unsigned getAddressSpace(clang::Expr *expr);
+
+    // \return The declaration of an expression or NULL if there is none. One
+    // implicit cast is allowed between the expression and its declaration.
+    const clang::DeclRefExpr *declRefExprViaImplicit(const clang::Expr *expr);
 }
 
 #endif // WEBCLVALIDATOR_TYPES

--- a/test/write-image.cl
+++ b/test/write-image.cl
@@ -1,6 +1,9 @@
 // RUN: %webcl-validator %s 2>&1 | grep -v CHECK | %FileCheck %s
 // RUN: %webcl-validator %s | kernel-runner --webcl --kernel write_image --image 10 10 | grep '9 (0.00, 9.00, 3.00, 4.00), (1.00, 9.00, 3.00, 4.00), (2.00, 9.00, 3.00, 4.00), (3.00, 9.00, 3.00, 4.00), (4.00, 9.00, 3.00, 4.00), (5.00, 9.00, 3.00, 4.00), (6.00, 9.00, 3.00, 4.00), (7.00, 9.00, 3.00, 4.00), (8.00, 9.00, 3.00, 4.00), (9.00, 9.00, 3.00, 4.00)'
 // RUN: ! (cat %s | kernel-runner --opencl --kernel write_image --image 10 10)
+
+// CHECK: _wcl_write_imagei_0(write_only image2d_t arg0
+
 __kernel void write_image(
     __global char* output,
     write_only image2d_t image)


### PR DESCRIPTION
This change prepends read_only or write_only to an image type, when a wrapper for write_image is being generated.

It moves function declRefExprViaImplicit to WebCLTypes, which provides means to find the declaration of a variable, even if it has been casted implicitly (once). This is used to find the image_type qualifiers attached to the declaration.
